### PR TITLE
Update Experiment Utils for Notebooks

### DIFF
--- a/cd_dynamax/src/utils/experiment_utils.py
+++ b/cd_dynamax/src/utils/experiment_utils.py
@@ -22,6 +22,13 @@ from .simulation_utils import *  # noqa: F403, F405
 from .physics_based_models import *  # noqa: F403, F405
 from .data_driven_models import *  # noqa: F403, F405
 
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.cdnlgssm_utils import *  # noqa: F403
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.models import *  # noqa: F403
+from cd_dynamax.src.continuous_discrete_linear_gaussian_ssm.models import *  # noqa: F403
+from cd_dynamax.dynamax.utils.bijectors import *  # noqa: F403
+import diffrax as dfx  # noqa: F401
+import optax  # noqa: F401
+
 
 # Generate time emissions
 def generate_t_emissions(


### PR DESCRIPTION
The notebooks were broken in the linting PR, as some unused imports were removed in linting that are actually executed in some `eval` statements. This adds them back and protects via noqa statements.