### PR TITLE
Add fastprogress dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "orbax-checkpoint>=0.9",
     "etils>=1.5",
     "dm-tree>=0.1.8",
+    "fastprogress>=1.0.0",
     "graphviz",
     "ipykernel"
 ]


### PR DESCRIPTION
This is a bona fide dependency of cd-dynamax, but is currently not required. This caused some issues in our CI for dynestyx.

This issue didn't pop up before because fastprogress used to be a blackjax dependency. However, blackjax just made it optional, and is therefore no longer installed by default.