### PR TITLE
Bump version to 0.3.1.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cd_dynamax"
-version = "0.2.5"
+version = "0.3.1"
 requires-python = ">=3.11"
 description = "Continuous-discrete dynamical systems with JAX and related libraries."
 readme = "README.md"


### PR DESCRIPTION
Bumps to 0.3.1 after #18. Should resolve any downstream CI issues for packages relying on CD-Dynamax.