### PR TITLE
default EnKF will not compute extra (heavy) diagnostics for speed)

### DIFF
--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -194,6 +194,7 @@ def _condition_on(
     t,
     perturb_measurements=True,
     inflation_delta=0.0,
+    compute_diagnostics: bool = False,
     warn: bool = True,
 ):
     """Condition a Gaussian potential on a new observation
@@ -296,24 +297,34 @@ def _condition_on(
     # Updated the particles
     x_cond = x_inflated + (K @ (y_data_perturbed - y_ensemble_infl).T).T
 
-    # --- Diagnostics ---
-    innovation = y - y_pred_mean
-    nis = innovation @ jnp.linalg.solve(S, innovation)  # normalized innovation squared
-    eigvals_S = jnp.linalg.eigvalsh(S)
-    min_eig_S = jnp.min(eigvals_S)
-    max_eig_S = jnp.max(eigvals_S)
-    cond_S = max_eig_S / min_eig_S
-
-    return {
+    cond_dict = {
         "loglik_step": ll_step,
         "x_cond": x_cond,
         "S": S,
         "K": K,
-        "innovation": innovation,
-        "nis": nis,
-        "min_eig_S": min_eig_S,
-        "cond_S": cond_S,
     }
+
+    if compute_diagnostics:
+        # These diagnostics are optional because they add extra solves /
+        # decompositions beyond the EnKF update itself.
+        innovation = y - y_pred_mean
+        nis = innovation @ jnp.linalg.solve(
+            S, innovation
+        )  # normalized innovation squared
+        eigvals_S = jnp.linalg.eigvalsh(S)
+        min_eig_S = jnp.min(eigvals_S)
+        max_eig_S = jnp.max(eigvals_S)
+        cond_S = max_eig_S / min_eig_S
+        cond_dict.update(
+            {
+                "innovation": innovation,
+                "nis": nis,
+                "min_eig_S": min_eig_S,
+                "cond_S": cond_S,
+            }
+        )
+
+    return cond_dict
 
 
 # EnKF filtering main function
@@ -329,7 +340,6 @@ def ensemble_kalman_filter(
         "predicted_means",
         "predicted_covariances",
         "marginal_loglik",
-        "posterior_extras",
     ],
     key: PRNGKey = jr.PRNGKey(0),
     warn: bool = True,
@@ -347,6 +357,9 @@ def ensemble_kalman_filter(
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
         output_fields: list of fields to include in the output.
+            Include "posterior_extras" to opt into per-step EnKF particles
+            and diagnostics. By default those extras are omitted to avoid
+            unnecessary storage and diagnostic computations.
         key: random generator key.
         warn: whether to warn about PSD issues.
 
@@ -354,6 +367,19 @@ def ensemble_kalman_filter(
         filtered_posterior: posterior object.
 
     """
+
+    if output_fields is None:
+        output_fields = [
+            "filtered_means",
+            "filtered_covariances",
+            "predicted_means",
+            "predicted_covariances",
+            "marginal_loglik",
+        ]
+
+    # Decide whether callers want EnKF extras. When omitted, skip the
+    # additional diagnostic math instead of only dropping the returned values.
+    include_posterior_extras = "posterior_extras" in output_fields
 
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
@@ -409,6 +435,7 @@ def ensemble_kalman_filter(
             t0,
             filter_hyperparams.perturb_measurements,
             filter_hyperparams.inflation_delta,
+            compute_diagnostics=include_posterior_extras,
             warn=warn,
         )
         # Filtered ensemble
@@ -444,22 +471,6 @@ def ensemble_kalman_filter(
         # Build carry and output states
         carry = (ll_cum, pred_x_ens)
 
-        # EnKF extras
-        posterior_extras = {
-            # Filtered/predicted particles here.
-            "x_ens_filtered": filtered_x_ens,
-            "x_ens_predicted": pred_x_ens,
-            # Other diagnostics
-            "loglik_step": cond_dict["loglik_step"],
-            "S": cond_dict["S"],
-            "K": cond_dict["K"],
-            "innovation": cond_dict["innovation"],
-            "nis": cond_dict["nis"],
-            "min_eig_S": cond_dict["min_eig_S"],
-            "cond_S": cond_dict["cond_S"],
-            "cond_K": jnp.linalg.cond(cond_dict["K"]),
-        }
-
         # Posterior output
         outputs = {
             # Default outputs
@@ -467,9 +478,22 @@ def ensemble_kalman_filter(
             "filtered_covariances": filtered_cov,
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
-            # Extras
-            "posterior_extras": posterior_extras,
         }
+        if include_posterior_extras:
+            outputs["posterior_extras"] = {
+                # Filtered/predicted particles here.
+                "x_ens_filtered": filtered_x_ens,
+                "x_ens_predicted": pred_x_ens,
+                # Other diagnostics
+                "loglik_step": cond_dict["loglik_step"],
+                "S": cond_dict["S"],
+                "K": cond_dict["K"],
+                "innovation": cond_dict["innovation"],
+                "nis": cond_dict["nis"],
+                "min_eig_S": cond_dict["min_eig_S"],
+                "cond_S": cond_dict["cond_S"],
+                "cond_K": jnp.linalg.cond(cond_dict["K"]),
+            }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 
         # Return carry and outputs

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
@@ -1054,7 +1054,8 @@ def cdnlgssm_filter(
         num_iter: number of linearizations around posterior for update step (default 1).
         output_fields: list of fields to return in posterior object.
             These can take the values "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", and "marginal_loglik".
+            "predicted_means", "predicted_covariances", "marginal_loglik",
+            and "posterior_extras".
         key: random key (e.g., for EnKF).
         warn: whether to issue warnings during filtering.
 

--- a/tests/test_filter_forecast_emissions.py
+++ b/tests/test_filter_forecast_emissions.py
@@ -12,6 +12,7 @@ from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm import (
     EKFHyperParams,
     UKFHyperParams,
     EnKFHyperParams,
+    cdnlgssm_filter,
 )
 
 from cd_dynamax.src.continuous_discrete_nonlinear_ssm import (
@@ -59,6 +60,63 @@ def test_filter_forecast_emissions(seed):
             key=seed,
         )
         print(f"... all tests passed for model config {model_config}!")
+
+
+def test_enkf_posterior_extras_are_opt_in(seed):
+    keys = make_key_sequence(seed)
+
+    cd_model, cd_params, _ = create_cddynamax_model_from_config(
+        config_path="./demos/python/configs/",
+        true_model_config_file="model/true_l63_mech",
+        overrides=None,
+    )
+
+    _, t_all = generate_t_emissions(
+        t0=0,
+        t1=1,
+        num_samples=25,
+        irregular_samples=False,
+        key=next(keys),
+    )
+    t_emissions = t_all[:20]
+
+    _, cd_emissions = cd_model.sample(
+        params=cd_params,
+        key=next(keys),
+        num_timesteps=len(t_emissions),
+        t_emissions=t_emissions,
+        inputs=None,
+    )
+
+    filter_hyperparams = EnKFHyperParams()
+
+    filtered_default = cdnlgssm_filter(
+        params=cd_params,
+        emissions=cd_emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=filter_hyperparams,
+        key=next(keys),
+    )
+    assert filtered_default.posterior_extras is None
+
+    filtered_with_extras = cdnlgssm_filter(
+        params=cd_params,
+        emissions=cd_emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=filter_hyperparams,
+        output_fields=[
+            "filtered_means",
+            "filtered_covariances",
+            "predicted_means",
+            "predicted_covariances",
+            "marginal_loglik",
+            "posterior_extras",
+        ],
+        key=next(keys),
+    )
+    assert filtered_with_extras.posterior_extras is not None
+    for diagnostic_key in ["innovation", "nis", "min_eig_S", "cond_S", "cond_K"]:
+        assert diagnostic_key in filtered_with_extras.posterior_extras
 
 
 # Check whether continuous-discrete model filtering and forecasting run


### PR DESCRIPTION
This change makes EnKF filtering performance-first by default. `ensemble_kalman_filter` no longer includes `posterior_extras` in its default outputs, and the extra diagnostic work behind those fields is now only computed when `"posterior_extras"` is explicitly requested in `output_fields`.

The core filter path is unchanged: filtered/predicted means, covariances, and marginal log-likelihood are still produced as before. The saved work is specifically the optional EnKF diagnostics such as normalized innovation squared, eigenvalue-based conditioning stats for `S`, and `cond_K`, along with the memory cost of returning per-step extras by default.

Tests were updated to cover both modes: default behavior omits `posterior_extras`, and opt-in behavior still returns the expected diagnostic fields.