### PR TITLE
support state-dependent diffusion L(x, u, t)

### DIFF
--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
@@ -119,9 +119,9 @@ def _predict(
         f = params.dynamics.drift.f
 
         # Get time-varying parameters
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t)
+        Qc_t = params.dynamics.diffusion_cov.f(m, u, t)
         L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t)
+            params.dynamics.diffusion_coefficient.f(m, u, t)
             * filter_hyperparams.cov_rescaling
         )
 
@@ -185,9 +185,9 @@ def _predict(
             dt = filter_hyperparams.dt_average
 
         # Covariance parameters at time t0
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t0)
+        Qc_t = params.dynamics.diffusion_cov.f(m, u, t0)
         L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t0)
+            params.dynamics.diffusion_coefficient.f(m, u, t0)
             * filter_hyperparams.cov_rescaling
         )
         # Covariance update
@@ -530,9 +530,9 @@ def _smooth(
         # TODO: possibly time- and parameter-dependent functions
         f = params.dynamics.drift.f
         # Get time-varying parameters
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t)
+        Qc_t = params.dynamics.diffusion_cov.f(m_filter, u, t)
         L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t)
+            params.dynamics.diffusion_coefficient.f(m_filter, u, t)
             * filter_hyperparams.cov_rescaling
         )
 
@@ -831,7 +831,7 @@ def extended_kalman_posterior_sample(
 
         # Get parameters and inputs for time t0
         u = inputs[t0_idx]
-        Q = params.dynamics.diffusion_cov.f(None, u, t0)
+        Q = params.dynamics.diffusion_cov.f(filtered_mean, u, t0)
 
         # Condition on next state
         smoothed_mean, smoothed_cov = _condition_on(

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
@@ -527,7 +527,6 @@ def _smooth(
         m_smooth, P_smooth = y
         m_filter, P_filter = args
 
-        # TODO: possibly time- and parameter-dependent functions
         f = params.dynamics.drift.f
         # Get time-varying parameters
         Qc_t = params.dynamics.diffusion_cov.f(m_filter, u, t)

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -113,9 +113,9 @@ def _predict(
         # First order EnKF diffusion
         def diffusion(t, y, args):
             # Get parameters at time t and input u
-            Qc_t = params.dynamics.diffusion_cov.f(None, u, t)
+            Qc_t = params.dynamics.diffusion_cov.f(y, u, t)
             L_t = (
-                params.dynamics.diffusion_coefficient.f(None, u, t)
+                params.dynamics.diffusion_coefficient.f(y, u, t)
                 * filter_hyperparams.cov_rescaling
             )
             Q_sqrt = jnp.linalg.cholesky(Qc_t)
@@ -155,26 +155,20 @@ def _predict(
             # but the same amount of noise is added after each measurement.
             dt = filter_hyperparams.dt_average
 
-        # Get diffusion parameters at time t0 and input u
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t0)
-        L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t0)
-            * filter_hyperparams.cov_rescaling
-        )
-
-        # Compute state noise covariance
-        state_noise_cov = dt * L_t @ Qc_t @ L_t.T  # D_hid x D_hid
-
-        # Noise realizations from MVN(0, state_noise_cov), for each particle particles (N x D_hid)
-        # Split keys for each particle
         key_array = jr.split(key, x.shape[0])
-        # vmap over particles
-        noise = vmap(
-            lambda key: jr.multivariate_normal(
-                key=key, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
-            ),
-            in_axes=0,
-        )(key_array)
+
+        def _sample_noise(x_i, key_i):
+            Qc_t = params.dynamics.diffusion_cov.f(x_i, u, t0)
+            L_t = (
+                params.dynamics.diffusion_coefficient.f(x_i, u, t0)
+                * filter_hyperparams.cov_rescaling
+            )
+            state_noise_cov = dt * L_t @ Qc_t @ L_t.T
+            return jr.multivariate_normal(
+                key=key_i, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
+            )
+
+        noise = vmap(_sample_noise, in_axes=(0, 0))(x_pred, key_array)
 
         # Add noise to predicted particles
         x_pred += noise

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -163,7 +163,7 @@ def _predict(
                 params.dynamics.diffusion_coefficient.f(x_i, u, t0)
                 * filter_hyperparams.cov_rescaling
             )
-            state_noise_cov = dt * L_t @ Qc_t @ L_t.T # D_hid x D_hid
+            state_noise_cov = dt * L_t @ Qc_t @ L_t.T  # D_hid x D_hid
             return jr.multivariate_normal(
                 key=key_i, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
             )

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -163,7 +163,7 @@ def _predict(
                 params.dynamics.diffusion_coefficient.f(x_i, u, t0)
                 * filter_hyperparams.cov_rescaling
             )
-            state_noise_cov = dt * L_t @ Qc_t @ L_t.T
+            state_noise_cov = dt * L_t @ Qc_t @ L_t.T # D_hid x D_hid
             return jr.multivariate_normal(
                 key=key_i, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
             )

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
@@ -214,9 +214,9 @@ def _predict(
             dt = filter_hyperparams.dt_average
 
         # Get diffusion parameters at time t0 and input u
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t0)
+        Qc_t = params.dynamics.diffusion_cov.f(m, u, t0)
         L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t0)
+            params.dynamics.diffusion_coefficient.f(m, u, t0)
             * filter_hyperparams.cov_rescaling
         )
         # Compute state noise covariance
@@ -237,9 +237,9 @@ def _predict(
             f = (
                 params.dynamics.drift.f
             )  # TODO: reconsider when we want time-varying dynamics functions
-            Qc_t = params.dynamics.diffusion_cov.f(None, u, t)
+            Qc_t = params.dynamics.diffusion_cov.f(m_t, u, t)
             L_t = (
-                params.dynamics.diffusion_coefficient.f(None, u, t)
+                params.dynamics.diffusion_coefficient.f(m_t, u, t)
                 * filter_hyperparams.cov_rescaling
             )
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
@@ -111,8 +111,8 @@ def compute_pushforward(
         f = params.dynamics.drift.f
 
         # Get time-varying parameters
-        Qc_t = params.dynamics.diffusion_cov.f(None, inputs, t)
-        L_t = params.dynamics.diffusion_coefficient.f(None, inputs, t)
+        Qc_t = params.dynamics.diffusion_cov.f(x, inputs, t)
+        L_t = params.dynamics.diffusion_coefficient.f(x, inputs, t)
 
         # Different SDE approximations to the dynamics
         # Zeroth-order (no gradient information),
@@ -964,8 +964,8 @@ def cdnlgssm_path_sample(
             return params.dynamics.drift.f(y, inpt, t)
 
         def diffusion(t, y, args):
-            Qc_t = params.dynamics.diffusion_cov.f(None, inpt, t)
-            L_t = params.dynamics.diffusion_coefficient.f(None, inpt, t)
+            Qc_t = params.dynamics.diffusion_cov.f(y, inpt, t)
+            L_t = params.dynamics.diffusion_coefficient.f(y, inpt, t)
             Q_sqrt = jnp.linalg.cholesky(Qc_t)
             combined_diffusion = L_t @ Q_sqrt
             return combined_diffusion
@@ -1261,9 +1261,9 @@ def cdnlgssm_forecast(
                 return params.dynamics.drift.f(y, inputs[t0_idx], t)
 
             def diffusion(t, y, args):
-                Qc_t = params.dynamics.diffusion_cov.f(None, inputs[t0_idx], t)
+                Qc_t = params.dynamics.diffusion_cov.f(y, inputs[t0_idx], t)
                 Q_sqrt = jnp.linalg.cholesky(Qc_t)
-                L_t = params.dynamics.diffusion_coefficient.f(None, inputs[t0_idx], t)
+                L_t = params.dynamics.diffusion_coefficient.f(y, inputs[t0_idx], t)
                 combined_diffusion = L_t @ Q_sqrt
                 return combined_diffusion
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_ssm/inference_dpf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_ssm/inference_dpf.py
@@ -112,9 +112,9 @@ def _predict(
     else:
 
         def diffusion(t, y, args):
-            Qc_t = params.dynamics.diffusion_cov.f(None, u, t)
+            Qc_t = params.dynamics.diffusion_cov.f(y, u, t)
             L_t = (
-                params.dynamics.diffusion_coefficient.f(None, u, t)
+                params.dynamics.diffusion_coefficient.f(y, u, t)
                 * filter_hyperparams.cov_rescaling
             )
             Q_sqrt = jnp.linalg.cholesky(Qc_t)
@@ -143,20 +143,20 @@ def _predict(
         else:
             dt = filter_hyperparams.dt_average
 
-        Qc_t = params.dynamics.diffusion_cov.f(None, u, t0)
-        L_t = (
-            params.dynamics.diffusion_coefficient.f(None, u, t0)
-            * filter_hyperparams.cov_rescaling
-        )
-        state_noise_cov = dt * L_t @ Qc_t @ L_t.T  # D_hid x D_hid
-
         key_array = jr.split(key, x.shape[0])
-        noise = vmap(
-            lambda key: jr.multivariate_normal(
-                key=key, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
-            ),
-            in_axes=0,
-        )(key_array)
+
+        def _sample_noise(x_i, key_i):
+            Qc_t = params.dynamics.diffusion_cov.f(x_i, u, t0)
+            L_t = (
+                params.dynamics.diffusion_coefficient.f(x_i, u, t0)
+                * filter_hyperparams.cov_rescaling
+            )
+            state_noise_cov = dt * L_t @ Qc_t @ L_t.T
+            return jr.multivariate_normal(
+                key=key_i, mean=jnp.zeros(x.shape[1]), cov=state_noise_cov
+            )
+
+        noise = vmap(_sample_noise, in_axes=(0, 0))(x_pred, key_array)
         x_pred += noise
     return x_pred
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_ssm/models.py
@@ -387,8 +387,8 @@ class ContDiscreteNonlinearSSM(SSM):
                 return params.dynamics.drift.f(y, u_prev_t, t)
 
             def diffusion(t, y, _):
-                Qc_t = params.dynamics.diffusion_cov.f(None, u_prev_t, t)
-                L_t = params.dynamics.diffusion_coefficient.f(None, u_prev_t, t)
+                Qc_t = params.dynamics.diffusion_cov.f(y, u_prev_t, t)
+                L_t = params.dynamics.diffusion_coefficient.f(y, u_prev_t, t)
                 Q_sqrt = jnp.linalg.cholesky(Qc_t)
                 return L_t @ Q_sqrt
 
@@ -818,10 +818,10 @@ def cdnlssm_forecast(
                 return params.dynamics.drift.f(y, forecast_inputs[t0_idx], t)
 
             def diffusion(t, y, args):
-                Qc_t = params.dynamics.diffusion_cov.f(None, forecast_inputs[t0_idx], t)
+                Qc_t = params.dynamics.diffusion_cov.f(y, forecast_inputs[t0_idx], t)
                 Q_sqrt = jnp.linalg.cholesky(Qc_t)
                 L_t = params.dynamics.diffusion_coefficient.f(
-                    None, forecast_inputs[t0_idx], t
+                    y, forecast_inputs[t0_idx], t
                 )
                 combined_diffusion = L_t @ Q_sqrt
                 return combined_diffusion

--- a/tests/test_state_dependent_diffusion.py
+++ b/tests/test_state_dependent_diffusion.py
@@ -1,0 +1,93 @@
+import jax.numpy as jnp
+import jax.random as jr
+from typing import NamedTuple
+
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm import (
+    ContDiscreteNonlinearGaussianSSM,
+)
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_ekf import (
+    EKFHyperParams,
+    extended_kalman_filter,
+)
+from cd_dynamax.src.continuous_discrete_nonlinear_ssm import ContDiscreteNonlinearSSM
+from cd_dynamax.src.continuous_discrete_nonlinear_ssm.inference_dpf import (
+    DPFHyperParams,
+    diff_particle_filter,
+)
+
+
+class StateDependentDiagonalDiffusion(NamedTuple):
+    scale: float = 0.1
+
+    def f(self, x, u=None, t=None):
+        if x is None:
+            raise ValueError("state-dependent diffusion requires a state argument")
+        x = jnp.atleast_1d(x)
+        return jnp.diag(1.0 + self.scale * jnp.square(x))
+
+
+def test_cdnlgssm_sample_path_supports_state_dependent_diffusion():
+    model = ContDiscreteNonlinearGaussianSSM(state_dim=1, emission_dim=1)
+    params, _ = model.initialize()
+    params = params._replace(
+        dynamics=params.dynamics._replace(
+            diffusion_coefficient=StateDependentDiagonalDiffusion()
+        )
+    )
+
+    states, emissions = model.sample_path(params, key=jr.PRNGKey(0), num_timesteps=3)
+
+    assert states.shape == (3, 1)
+    assert emissions.shape == (3, 1)
+    assert jnp.all(jnp.isfinite(states))
+    assert jnp.all(jnp.isfinite(emissions))
+
+
+def test_extended_kalman_filter_supports_state_dependent_diffusion():
+    model = ContDiscreteNonlinearGaussianSSM(state_dim=1, emission_dim=1)
+    params, _ = model.initialize()
+    params = params._replace(
+        dynamics=params.dynamics._replace(
+            diffusion_coefficient=StateDependentDiagonalDiffusion()
+        )
+    )
+
+    emissions = jnp.zeros((2, 1))
+    t_emissions = jnp.array([[0.0], [0.1]])
+
+    posterior = extended_kalman_filter(
+        params,
+        emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=EKFHyperParams(state_order="first"),
+    )
+
+    assert posterior.filtered_means.shape == (2, 1)
+    assert posterior.predicted_covariances.shape == (2, 1, 1)
+    assert jnp.all(jnp.isfinite(posterior.filtered_means))
+    assert jnp.all(jnp.isfinite(posterior.predicted_covariances))
+
+
+def test_diff_particle_filter_supports_state_dependent_diffusion():
+    model = ContDiscreteNonlinearSSM(state_dim=1, emission_dim=1)
+    params, _ = model.initialize()
+    params = params._replace(
+        dynamics=params.dynamics._replace(
+            diffusion_coefficient=StateDependentDiagonalDiffusion()
+        )
+    )
+
+    emissions = jnp.zeros((2, 1))
+    ts = jnp.array([0.0, 0.1])
+
+    particles, log_weights, log_evidence = diff_particle_filter(
+        jr.PRNGKey(0),
+        params,
+        emissions,
+        ts=ts,
+        hyperparams=DPFHyperParams(N_particles=8),
+    )
+
+    assert particles.shape == (2, 8, 1)
+    assert log_weights.shape == (2, 8)
+    assert jnp.isfinite(log_evidence)


### PR DESCRIPTION
Addresses #25.

This PR fixes continuous-time nonlinear diffusion evaluation so state-dependent diffusion functions are called with the current state/mean/particle rather than `None`. It updates the nonlinear Gaussian and nonlinear non-Gaussian sampling, forecasting, and filtering codepaths accordingly, including per-particle noise injection in EnKF/DPF zeroth-discrete branches. It also adds regression tests that should fail if diffusion is evaluated without a valid state argument.