### PR TITLE
Make CD filters return predicted observation distributions

### DIFF
--- a/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
@@ -115,6 +115,9 @@ class PosteriorGSSMFiltered(NamedTuple):
     :param marginal_loglik: marginal log likelihood, $p(y_{1:T} \mid u_{1:T})$
     :param filtered_means: array of filtered means $\mathbb{E}[z_t \mid y_{1:t}, u_{1:t}]$
     :param filtered_covariances: array of filtered covariances $\mathrm{Cov}[z_t \mid y_{1:t}, u_{1:t}]$
+    :param predicted_means: optional array of one-step-ahead state means $\mathbb{E}[z_{t+1} \mid y_{1:t}, u_{1:t}]$
+    :param predicted_covariances: optional array of one-step-ahead state covariances $\mathrm{Cov}[z_{t+1} \mid y_{1:t}, u_{1:t}]$
+    :param posterior_extras: optional dictionary of filter-specific per-step diagnostics
 
     """
     # Default attributes

--- a/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
@@ -11,7 +11,7 @@ from tensorflow_probability.substrates.jax.distributions import (
 
 from jax.tree_util import tree_map
 from jaxtyping import Array, Float
-from typing import NamedTuple, Optional, Union, Tuple
+from typing import Collection, NamedTuple, Optional, Union, Tuple
 from ..utils.utils import psd_solve, symmetrize
 from ..parameters import ParameterProperties
 from ..types import PRNGKey, Scalar
@@ -112,12 +112,27 @@ class ParamsLGSSM(NamedTuple):
 class PosteriorGSSMFiltered(NamedTuple):
     r"""Marginals of the Gaussian filtering posterior.
 
+    Time indexing convention:
+    `filtered_*[t]` corresponds to $x_{t \mid t}$,
+    `predicted_*[t]` corresponds to $x_{t+1 \mid t}$,
+    and predictive observation quantities such as `y_pred_*[t]` and
+    `y_obs_pred_*[t]` correspond to the observation-time prior
+    $p(y_t \mid y_{1:t-1})$, i.e. they are computed from $x_{t \mid t-1}$.
+
     :param marginal_loglik: marginal log likelihood, $p(y_{1:T} \mid u_{1:T})$
-    :param filtered_means: array of filtered means $\mathbb{E}[z_t \mid y_{1:t}, u_{1:t}]$
-    :param filtered_covariances: array of filtered covariances $\mathrm{Cov}[z_t \mid y_{1:t}, u_{1:t}]$
-    :param predicted_means: optional array of one-step-ahead state means $\mathbb{E}[z_{t+1} \mid y_{1:t}, u_{1:t}]$
-    :param predicted_covariances: optional array of one-step-ahead state covariances $\mathrm{Cov}[z_{t+1} \mid y_{1:t}, u_{1:t}]$
-    :param posterior_extras: optional dictionary of filter-specific per-step diagnostics
+    :param filtered_means: array of filtered means $\mathbb{E}[x_t \mid y_{1:t}, u_{1:t}]$
+    :param filtered_covariances: array of filtered covariances $\mathrm{Cov}[x_t \mid y_{1:t}, u_{1:t}]$
+    :param predicted_means: optional array of one-step-ahead state means $\mathbb{E}[x_{t+1} \mid y_{1:t}, u_{1:t}]$
+    :param predicted_covariances: optional array of one-step-ahead state covariances $\mathrm{Cov}[x_{t+1} \mid y_{1:t}, u_{1:t}]$
+    :param filtered_ensembles: optional array of filtered state ensembles approximating $p(x_t \mid y_{1:t}, u_{1:t})$
+    :param predicted_ensembles: optional array of one-step-ahead predicted state ensembles approximating $p(x_{t+1} \mid y_{1:t}, u_{1:t})$
+    :param y_pred_mean: optional array of predictive emission means for $p(y_t \mid y_{1:t-1}, u_{1:t})$, before adding observation noise
+    :param y_pred_cov: optional array of predictive emission covariances for $p(y_t \mid y_{1:t-1}, u_{1:t})$, before adding observation noise
+    :param y_obs_pred_mean: optional array of predictive observation means for $p(y_t \mid y_{1:t-1}, u_{1:t})$
+    :param y_obs_pred_cov: optional array of predictive observation covariances for $p(y_t \mid y_{1:t-1}, u_{1:t})$, including observation noise
+    :param y_ens_pred: optional array of predictive emission ensembles for observation time $t$, obtained from the predicted state ensemble for $x_{t \mid t-1}$
+    :param y_obs_ens_pred: optional array of predictive observation ensembles for observation time $t$, obtained by adding sampled observation noise to `y_ens_pred`
+    :param posterior_extras: optional dictionary of filter-specific per-step diagnostics that do not fit the standard filtered posterior schema
 
     """
     # Default attributes
@@ -126,8 +141,63 @@ class PosteriorGSSMFiltered(NamedTuple):
     filtered_covariances: Optional[Float[Array, "ntime state_dim state_dim"]] = None
     predicted_means: Optional[Float[Array, "ntime state_dim"]] = None
     predicted_covariances: Optional[Float[Array, "ntime state_dim state_dim"]] = None
+    filtered_ensembles: Optional[Float[Array, "ntime ensemble_size state_dim"]] = None
+    predicted_ensembles: Optional[Float[Array, "ntime ensemble_size state_dim"]] = None
+    y_pred_mean: Optional[Float[Array, "ntime emission_dim"]] = None
+    y_pred_cov: Optional[Float[Array, "ntime emission_dim emission_dim"]] = None
+    y_obs_pred_mean: Optional[Float[Array, "ntime emission_dim"]] = None
+    y_obs_pred_cov: Optional[Float[Array, "ntime emission_dim emission_dim"]] = None
+    y_ens_pred: Optional[Float[Array, "ntime ensemble_size emission_dim"]] = None
+    y_obs_ens_pred: Optional[Float[Array, "ntime ensemble_size emission_dim"]] = None
     # Additional extras
     posterior_extras: Optional[dict] = None
+
+
+FILTERED_POSTERIOR_FIELD_NAMES = (
+    "marginal_loglik",
+    "filtered_means",
+    "filtered_covariances",
+    "predicted_means",
+    "predicted_covariances",
+    "filtered_ensembles",
+    "predicted_ensembles",
+    "y_pred_mean",
+    "y_pred_cov",
+    "y_obs_pred_mean",
+    "y_obs_pred_cov",
+    "y_ens_pred",
+    "y_obs_ens_pred",
+    "posterior_extras",
+)
+
+
+def validate_filtered_posterior_output_fields(
+    filter_name: str,
+    output_fields: Optional[Collection[str]],
+    supported_fields: Collection[str],
+):
+    """Validate requested top-level filtered posterior fields."""
+
+    if output_fields is None:
+        return
+
+    valid_fields = set(FILTERED_POSTERIOR_FIELD_NAMES)
+    supported_fields = set(supported_fields)
+    requested_fields = list(output_fields)
+
+    unknown_fields = sorted(set(requested_fields) - valid_fields)
+    if unknown_fields:
+        raise ValueError(
+            f"Unknown output_fields for {filter_name}: {unknown_fields}. "
+            f"Valid top-level filtered posterior fields are: {sorted(valid_fields)}."
+        )
+
+    unsupported_fields = sorted(set(requested_fields) - supported_fields)
+    if unsupported_fields:
+        raise ValueError(
+            f"output_fields {unsupported_fields} are not available for {filter_name}. "
+            f"Available fields are: {sorted(supported_fields)}."
+        )
 
 class PosteriorGSSMSmoothed(NamedTuple):
     r"""Marginals of the Gaussian filtering and smoothing posterior.

--- a/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/dynamax/linear_gaussian_ssm/inference.py
@@ -124,15 +124,15 @@ class PosteriorGSSMFiltered(NamedTuple):
     :param filtered_covariances: array of filtered covariances $\mathrm{Cov}[x_t \mid y_{1:t}, u_{1:t}]$
     :param predicted_means: optional array of one-step-ahead state means $\mathbb{E}[x_{t+1} \mid y_{1:t}, u_{1:t}]$
     :param predicted_covariances: optional array of one-step-ahead state covariances $\mathrm{Cov}[x_{t+1} \mid y_{1:t}, u_{1:t}]$
-    :param filtered_ensembles: optional array of filtered state ensembles approximating $p(x_t \mid y_{1:t}, u_{1:t})$
-    :param predicted_ensembles: optional array of one-step-ahead predicted state ensembles approximating $p(x_{t+1} \mid y_{1:t}, u_{1:t})$
-    :param y_pred_mean: optional array of predictive emission means for $p(y_t \mid y_{1:t-1}, u_{1:t})$, before adding observation noise
-    :param y_pred_cov: optional array of predictive emission covariances for $p(y_t \mid y_{1:t-1}, u_{1:t})$, before adding observation noise
+    :param filtered_ensembles: When filtering with EnKF, optional array of filtered state ensembles approximating $p(x_t \mid y_{1:t}, u_{1:t})$
+    :param predicted_ensembles: When filtering with EnKF, optional array of one-step-ahead predicted state ensembles approximating $p(x_{t+1} \mid y_{1:t}, u_{1:t})$
+    :param y_pred_mean: optional array of predictive emission means for $p(h(x_t) \mid y_{1:t-1}, u_{1:t})$,  i.e., before adding observation noise to h(x_t)
+    :param y_pred_cov: optional array of predictive emission covariances for $p(h(x_t) \mid y_{1:t-1}, u_{1:t})$, i.e., before adding observation noise to h(x_t)
     :param y_obs_pred_mean: optional array of predictive observation means for $p(y_t \mid y_{1:t-1}, u_{1:t})$
     :param y_obs_pred_cov: optional array of predictive observation covariances for $p(y_t \mid y_{1:t-1}, u_{1:t})$, including observation noise
-    :param y_ens_pred: optional array of predictive emission ensembles for observation time $t$, obtained from the predicted state ensemble for $x_{t \mid t-1}$
-    :param y_obs_ens_pred: optional array of predictive observation ensembles for observation time $t$, obtained by adding sampled observation noise to `y_ens_pred`
-    :param posterior_extras: optional dictionary of filter-specific per-step diagnostics that do not fit the standard filtered posterior schema
+    :param y_ens_pred: When filtering with EnKF, optional array of predictive emission ensembles for observation time $t$, obtained from the predicted state ensemble for $x_{t \mid t-1}$
+    :param y_obs_ens_pred: When filtering with EnKF, optional array of predictive observation ensembles for observation time $t$, obtained by adding sampled observation noise to `y_ens_pred`
+    :param posterior_extras: When filtering with EnKF, optional dictionary of filter-specific per-step diagnostics that do not fit the standard filtered posterior schema
 
     """
     # Default attributes

--- a/cd_dynamax/dynamax/nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/dynamax/nonlinear_gaussian_ssm/inference_ekf.py
@@ -101,8 +101,12 @@ def extended_kalman_filter(
         num_iter: number of linearizations around posterior for update step (default 1).
         inputs: optional array of inputs.
         output_fields: list of fields to return in posterior object.
-            These can take the values "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", and "marginal_loglik".
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
 
     Returns:
         post: posterior object.

--- a/cd_dynamax/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
+++ b/cd_dynamax/dynamax/nonlinear_gaussian_ssm/inference_ukf.py
@@ -151,6 +151,13 @@ def unscented_kalman_filter(
         emissions: array of observations.
         hyperparams: hyper-parameters.
         inputs: optional array of inputs.
+        output_fields: list of fields to return in posterior object.
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
 
     Returns:
         filtered_posterior: posterior object.

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
@@ -137,19 +137,26 @@ def preprocess_args(f):
         filter_hyperparams = bound_args.arguments["filter_hyperparams"]
         inputs = bound_args.arguments["inputs"]
         warn = bound_args.arguments["warn"]
+        output_fields = bound_args.arguments.get("output_fields")
 
         num_timesteps = len(emissions)
         full_params, inputs = preprocess_params_and_inputs(
             params, num_timesteps, inputs
         )
 
-        return f(
-            full_params,
-            emissions,
-            t_emissions,
+        call_kwargs = dict(
+            params=full_params,
+            emissions=emissions,
+            t_emissions=t_emissions,
             filter_hyperparams=filter_hyperparams,
             inputs=inputs,
             warn=warn,
+        )
+        if output_fields is not None:
+            call_kwargs["output_fields"] = output_fields
+
+        return f(
+            **call_kwargs,
         )
 
     return wrapper
@@ -334,6 +341,14 @@ def _condition_on(m, P, H, D, d, R, u, y, warn: bool = True):
     return mu_cond, Sigma_cond
 
 
+def _emission_predicted_moments(m, P, H, D, d, u, warn: bool = True):
+    """Compute the predictive emission moments under the linear Gaussian model."""
+
+    y_pred_mean = H @ m + D @ u + d
+    y_pred_cov = psd(H @ P @ H.T, warn=warn)
+    return y_pred_mean, y_pred_cov
+
+
 # CD-LGSSM filtering implementation: Kalman filter
 @preprocess_args
 def cdlgssm_filter(
@@ -342,6 +357,13 @@ def cdlgssm_filter(
     t_emissions: Optional[Float[Array, "num_timesteps 1"]] = None,
     filter_hyperparams: Optional[KFHyperParams] = KFHyperParams(),
     inputs: Optional[Float[Array, "num_timesteps input_dim"]] = None,
+    output_fields: Optional[List[str]] = [
+        "filtered_means",
+        "filtered_covariances",
+        "predicted_means",
+        "predicted_covariances",
+        "posterior_extras",
+    ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
     r"""Run a Continuous Discrete Kalman filter
@@ -353,6 +375,14 @@ def cdlgssm_filter(
         t_emissions: continuous-time specific time instants of observations: if not None, it is an array
         filter_hyperparams: hyperparameters for the filter.
         inputs: optional array of inputs.
+        output_fields: list of top-level posterior fields to return.
+            These can include "filtered_means", "filtered_covariances",
+            "predicted_means", "predicted_covariances", "marginal_loglik",
+            and "posterior_extras". For the linear Kalman filter,
+            `posterior_extras` stores per-step noiseless predictive emission
+            moments `y_pred_mean` / `y_pred_cov`, and data-facing predictive
+            moments `y_obs_pred_mean` / `y_obs_pred_cov`, where
+            `y_obs_pred_cov = y_pred_cov + R`.
         warn: whether to issue warnings during filtering (e.g., PSD issues).
 
     Returns:
@@ -405,8 +435,14 @@ def cdlgssm_filter(
         u = inputs[t0_idx]
         y = emissions[t0_idx]
 
+        y_pred_mean, y_pred_cov = _emission_predicted_moments(
+            pred_mean, pred_cov, H, D, d, u, warn=warn
+        )
+        y_obs_pred_mean = y_pred_mean
+        y_obs_pred_cov = psd(y_pred_cov + R, warn=warn)
+
         # Update the log likelihood
-        ll += MVN(H @ pred_mean + D @ u + d, H @ pred_cov @ H.T + R).log_prob(y)
+        ll += MVN(y_obs_pred_mean, y_obs_pred_cov).log_prob(y)
 
         # Condition on this emission
         filtered_mean, filtered_cov = _condition_on(
@@ -427,30 +463,32 @@ def cdlgssm_filter(
             filtered_mean, filtered_cov, F, C, B, b, Q, u, warn=warn
         )
 
+        outputs = {
+            "filtered_means": filtered_mean,
+            "filtered_covariances": filtered_cov,
+            "predicted_means": pred_mean,
+            "predicted_covariances": pred_cov,
+            "posterior_extras": {
+                "y_pred_mean": y_pred_mean,
+                "y_pred_cov": y_pred_cov,
+                "y_obs_pred_mean": y_obs_pred_mean,
+                "y_obs_pred_cov": y_obs_pred_cov,
+            },
+        }
+        outputs = {key: val for key, val in outputs.items() if key in output_fields}
+
         # Return the carry and outputs
-        return (ll, pred_mean, pred_cov), (
-            filtered_mean,
-            filtered_cov,
-            pred_mean,
-            pred_cov,
-        )
+        return (ll, pred_mean, pred_cov), outputs
 
     # The Kalman filter
     # Initial carry
     carry = (0.0, params.initial.mean, params.initial.cov)
     # Scan over all time steps
-    (ll, _, _), (filtered_means, filtered_covs, pred_means, pred_covs) = lax.scan(
-        _step, carry, (t0, t1, t0_idx)
-    )
+    (ll, _, _), outputs = lax.scan(_step, carry, (t0, t1, t0_idx))
+    outputs = {"marginal_loglik": ll, **outputs}
 
     # Return the posterior object
-    return PosteriorGSSMFiltered(
-        marginal_loglik=ll,
-        filtered_means=filtered_means,
-        filtered_covariances=filtered_covs,
-        predicted_means=pred_means,
-        predicted_covariances=pred_covs,
-    )
+    return PosteriorGSSMFiltered(**outputs)
 
 
 # Kalmam Smoothing equations, in continuous-time

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
@@ -27,6 +27,7 @@ from cd_dynamax.dynamax.utils.utils import psd_solve
 from cd_dynamax.dynamax.linear_gaussian_ssm.inference import (
     PosteriorGSSMFiltered,
     PosteriorGSSMSmoothed,
+    validate_filtered_posterior_output_fields,
 )
 
 # Initial and emission parameter classes are equivalent
@@ -52,6 +53,19 @@ from ..utils.debug_utils import psd
 tfb = tfp.bijectors
 
 DEBUG = False
+
+
+CDLGSSM_FILTER_OUTPUT_FIELDS = (
+    "marginal_loglik",
+    "filtered_means",
+    "filtered_covariances",
+    "predicted_means",
+    "predicted_covariances",
+    "y_pred_mean",
+    "y_pred_cov",
+    "y_obs_pred_mean",
+    "y_obs_pred_cov",
+)
 
 
 #### Helper functions
@@ -362,7 +376,6 @@ def cdlgssm_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
-        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -376,13 +389,16 @@ def cdlgssm_filter(
         filter_hyperparams: hyperparameters for the filter.
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to return.
-            These can include "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", "marginal_loglik",
-            and "posterior_extras". For the linear Kalman filter,
-            `posterior_extras` stores per-step noiseless predictive emission
-            moments `y_pred_mean` / `y_pred_cov`, and data-facing predictive
-            moments `y_obs_pred_mean` / `y_obs_pred_cov`, where
-            `y_obs_pred_cov = y_pred_cov + R`.
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
         warn: whether to issue warnings during filtering (e.g., PSD issues).
 
     Returns:
@@ -391,6 +407,10 @@ def cdlgssm_filter(
     # Double-check filter_hyperparams is not None
     if filter_hyperparams is None:
         filter_hyperparams = KFHyperParams()
+
+    validate_filtered_posterior_output_fields(
+        "cdlgssm_filter", output_fields, CDLGSSM_FILTER_OUTPUT_FIELDS
+    )
 
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
@@ -468,12 +488,10 @@ def cdlgssm_filter(
             "filtered_covariances": filtered_cov,
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
-            "posterior_extras": {
-                "y_pred_mean": y_pred_mean,
-                "y_pred_cov": y_pred_cov,
-                "y_obs_pred_mean": y_obs_pred_mean,
-                "y_obs_pred_cov": y_obs_pred_cov,
-            },
+            "y_pred_mean": y_pred_mean,
+            "y_pred_cov": y_pred_cov,
+            "y_obs_pred_mean": y_obs_pred_mean,
+            "y_obs_pred_cov": y_obs_pred_cov,
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 
@@ -1148,12 +1166,10 @@ def cdlgssm_forecast(
         inputs: optional array of inputs, of shape (1 + num_timesteps) \times input_dim
             - The extra input is needed for the initial emission, i.e., it should be at time t_init
         output_fields: list of fields to return in posterior object.
-            These can take the values
-                If we forecast Gaussian distributions, based on filtering methods
-                    "forecasted_state_means",
-                    "forecasted_state_covariances",
-                If we forecast paths, based on solving the SDE
-                    "forecasted_state_path".
+            Options:
+            `"forecasted_state_means"` (default for Gaussian forecasts)
+            `"forecasted_state_covariances"` (default for Gaussian forecasts)
+            `"forecasted_state_path"` (for point-initialized path forecasts)
         key: random key (e.g., for Ensemble Kalman).
         diffeqsolve_settings: settings for the SDE solver
         warn: whether to issue warnings during filtering (e.g., PSD issues).

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
@@ -4,7 +4,7 @@ import jax.random as jr
 from jaxtyping import Array, Float
 
 # Type annotations
-from typing import Any, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 from typing_extensions import Protocol
 
 # Distributions, compatible with JAX, from TensorFlow Probability
@@ -510,6 +510,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
         t_emissions: Optional[Float[Array, "ntime 1"]] = None,
         filter_hyperparams: Optional[KFHyperParams] = KFHyperParams(),
         inputs: Optional[Float[Array, "ntime input_dim"]] = None,
+        output_fields: Optional[List[str]] = None,
         warn: bool = True,
     ) -> PosteriorGSSMFiltered:
         r"""Run the CD-Kalman filter to compute the filtered posterior distribution over states.
@@ -519,6 +520,9 @@ class ContDiscreteLinearGaussianSSM(SSM):
             t_emissions: continuous-time specific time instants of observations: if not None, it is an array
             filter_hyperparams: hyperparameters for the Kalman filter.
             inputs: optional sequence of inputs.
+            output_fields: Which top-level posterior fields to return from the
+                filter. Include `"posterior_extras"` to keep predictive
+                emission moments.
             warn: whether to warn about numerical issues.
         Returns:
             filtered posterior distribution over states.
@@ -526,7 +530,13 @@ class ContDiscreteLinearGaussianSSM(SSM):
 
         # Directly run the CD-Kalman filter
         return cdlgssm_filter(
-            params, emissions, t_emissions, filter_hyperparams, inputs, warn=warn
+            params,
+            emissions,
+            t_emissions,
+            filter_hyperparams,
+            inputs,
+            output_fields=output_fields,
+            warn=warn,
         )
 
     # High-level, user-friendly interface combining filtering and forecasting steps

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
@@ -510,7 +510,12 @@ class ContDiscreteLinearGaussianSSM(SSM):
         t_emissions: Optional[Float[Array, "ntime 1"]] = None,
         filter_hyperparams: Optional[KFHyperParams] = KFHyperParams(),
         inputs: Optional[Float[Array, "ntime input_dim"]] = None,
-        output_fields: Optional[List[str]] = None,
+        output_fields: Optional[List[str]] = [
+            "filtered_means",
+            "filtered_covariances",
+            "predicted_means",
+            "predicted_covariances",
+        ],
         warn: bool = True,
     ) -> PosteriorGSSMFiltered:
         r"""Run the CD-Kalman filter to compute the filtered posterior distribution over states.
@@ -521,8 +526,19 @@ class ContDiscreteLinearGaussianSSM(SSM):
             filter_hyperparams: hyperparameters for the Kalman filter.
             inputs: optional sequence of inputs.
             output_fields: Which top-level posterior fields to return from the
-                filter. Include `"posterior_extras"` to keep predictive
-                emission moments.
+                filter. Options:
+                `"filtered_means"` (default)
+                `"filtered_covariances"` (default)
+                `"predicted_means"` (default)
+                `"predicted_covariances"` (default)
+                `"marginal_loglik"`
+                `"y_pred_mean"`
+                `"y_pred_cov"`
+                `"y_obs_pred_mean"`
+                `"y_obs_pred_cov"`
+                Predictive emission fields are available directly as
+                top-level filtered posterior outputs. Unsupported fields raise
+                a `ValueError`.
             warn: whether to warn about numerical issues.
         Returns:
             filtered posterior distribution over states.

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
@@ -275,6 +275,15 @@ def _condition_on(
     return mu_cond, psd(Sigma_cond, warn=warn)
 
 
+def _emission_predicted_moments(m, P, h, H, u, t, warn: bool = True):
+    """Compute the EKF Gaussian approximation to the predictive emission moments."""
+
+    H_x = H(m, u, t)
+    y_pred_mean = h(m, u, t)
+    y_pred_cov = psd(H_x @ P @ H_x.T, warn=warn)
+    return y_pred_mean, y_pred_cov
+
+
 # EKF filtering main function
 def extended_kalman_filter(
     params: ParamsCDNLGSSM,
@@ -288,6 +297,7 @@ def extended_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
+        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -308,9 +318,11 @@ def extended_kalman_filter(
         filter_hyperparams: hyper-parameters of the EKF, related to the approximation order
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 1).
-        output_fields: list of fields to return in posterior object.
-            These can take the values "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", and "marginal_loglik".
+        output_fields: list of top-level posterior fields to return.
+            These can include "filtered_means", "filtered_covariances",
+            "predicted_means", "predicted_covariances", "marginal_loglik",
+            and "posterior_extras". For EKF, `posterior_extras` stores
+            per-step `y_pred_mean` and `y_pred_cov`.
         warn: whether to issue warnings during filtering (e.g., PSD issues).
 
     Returns:
@@ -363,14 +375,12 @@ def extended_kalman_filter(
         y = emissions[t0_idx]
         R = params.emissions.emission_cov.f(None, u, t0)
 
-        # Update the log likelihood
-        # According to first order EKF update,
-        # using Jacobian at predicted mean, inputs and time
-        H_x = H(pred_mean, u, t0)
-        # Log likelihood increment, given by Gaussian at observed emission
-        ll += MVN(h(pred_mean, u, t0), H_x @ pred_cov @ H_x.T + R).log_prob(
-            jnp.atleast_1d(y)
+        y_pred_mean, y_pred_cov = _emission_predicted_moments(
+            pred_mean, pred_cov, h, H, u, t0, warn=warn
         )
+
+        # Log likelihood increment under the Gaussianized predictive emission model.
+        ll += MVN(y_pred_mean, y_pred_cov + R).log_prob(jnp.atleast_1d(y))
 
         # Condition on this emission
         filtered_mean, filtered_cov = _condition_on(
@@ -407,6 +417,10 @@ def extended_kalman_filter(
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
             "marginal_loglik": ll,
+            "posterior_extras": {
+                "y_pred_mean": y_pred_mean,
+                "y_pred_cov": y_pred_cov,
+            },
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 
@@ -438,6 +452,7 @@ def iterated_extended_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
+        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -457,7 +472,8 @@ def iterated_extended_kalman_filter(
         filter_hyperparams: hyper-parameters of the EKF, related to the approximation order
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 2).
-        output_fields: list of fields to return in posterior object.
+        output_fields: list of top-level posterior fields to return.
+            `posterior_extras` stores per-step `y_pred_mean` and `y_pred_cov`.
         warn: whether to issue warnings during filtering (e.g., PSD issues).
     Returns:
         post: posterior object.

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
@@ -25,6 +25,7 @@ from cd_dynamax.dynamax.utils.utils import psd_solve
 from cd_dynamax.dynamax.linear_gaussian_ssm.inference import (
     PosteriorGSSMFiltered,
     PosteriorGSSMSmoothed,
+    validate_filtered_posterior_output_fields,
 )
 
 # Our codebase
@@ -43,6 +44,19 @@ from ..utils.debug_utils import psd, lax_scan
 tfb = tfp.bijectors
 
 DEBUG = False
+
+
+EKF_FILTER_OUTPUT_FIELDS = (
+    "marginal_loglik",
+    "filtered_means",
+    "filtered_covariances",
+    "predicted_means",
+    "predicted_covariances",
+    "y_pred_mean",
+    "y_pred_cov",
+    "y_obs_pred_mean",
+    "y_obs_pred_cov",
+)
 
 #### Helper functions
 # Helper functions --- from dynamax
@@ -297,7 +311,6 @@ def extended_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
-        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -319,19 +332,27 @@ def extended_kalman_filter(
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 1).
         output_fields: list of top-level posterior fields to return.
-            These can include "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", "marginal_loglik",
-            and "posterior_extras". For EKF, `posterior_extras` stores
-            per-step noiseless predictive emission moments
-            `y_pred_mean` / `y_pred_cov`, and data-facing predictive moments
-            `y_obs_pred_mean` / `y_obs_pred_cov`, where
-            `y_obs_pred_cov = y_pred_cov + R`.
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
         warn: whether to issue warnings during filtering (e.g., PSD issues).
 
     Returns:
         filtered_posterior: posterior object.
 
     """
+
+    # Figure out timestamps, as vectors to scan over
+    validate_filtered_posterior_output_fields(
+        "extended_kalman_filter", output_fields, EKF_FILTER_OUTPUT_FIELDS
+    )
 
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
@@ -422,12 +443,10 @@ def extended_kalman_filter(
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
             "marginal_loglik": ll,
-            "posterior_extras": {
-                "y_pred_mean": y_pred_mean,
-                "y_pred_cov": y_pred_cov,
-                "y_obs_pred_mean": y_obs_pred_mean,
-                "y_obs_pred_cov": y_obs_pred_cov,
-            },
+            "y_pred_mean": y_pred_mean,
+            "y_pred_cov": y_pred_cov,
+            "y_obs_pred_mean": y_obs_pred_mean,
+            "y_obs_pred_cov": y_obs_pred_cov,
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 
@@ -459,7 +478,6 @@ def iterated_extended_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
-        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -480,8 +498,16 @@ def iterated_extended_kalman_filter(
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 2).
         output_fields: list of top-level posterior fields to return.
-            `posterior_extras` stores both noiseless predictive emission
-            moments and data-facing predictive moments with observation noise.
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
         warn: whether to issue warnings during filtering (e.g., PSD issues).
     Returns:
         post: posterior object.
@@ -920,7 +946,10 @@ def forecast_extended_kalman_filter(
         t_forecast: continuous-time specific time instants to forecast
         filter_hyperparams: hyper-parameters of the EKF, related to the approximation order
         inputs: optional array of inputs.
-        output_fields: list of fields to return
+        output_fields: list of fields to return.
+            Options:
+            `"forecasted_state_means"` (default)
+            `"forecasted_state_covariances"` (default)
         warn: whether to issue warnings (e.g., about PSD issues)
 
     Returns:

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ekf.py
@@ -322,7 +322,10 @@ def extended_kalman_filter(
             These can include "filtered_means", "filtered_covariances",
             "predicted_means", "predicted_covariances", "marginal_loglik",
             and "posterior_extras". For EKF, `posterior_extras` stores
-            per-step `y_pred_mean` and `y_pred_cov`.
+            per-step noiseless predictive emission moments
+            `y_pred_mean` / `y_pred_cov`, and data-facing predictive moments
+            `y_obs_pred_mean` / `y_obs_pred_cov`, where
+            `y_obs_pred_cov = y_pred_cov + R`.
         warn: whether to issue warnings during filtering (e.g., PSD issues).
 
     Returns:
@@ -378,9 +381,11 @@ def extended_kalman_filter(
         y_pred_mean, y_pred_cov = _emission_predicted_moments(
             pred_mean, pred_cov, h, H, u, t0, warn=warn
         )
+        y_obs_pred_mean = y_pred_mean
+        y_obs_pred_cov = psd(y_pred_cov + R, warn=warn)
 
         # Log likelihood increment under the Gaussianized predictive emission model.
-        ll += MVN(y_pred_mean, y_pred_cov + R).log_prob(jnp.atleast_1d(y))
+        ll += MVN(y_obs_pred_mean, y_obs_pred_cov).log_prob(jnp.atleast_1d(y))
 
         # Condition on this emission
         filtered_mean, filtered_cov = _condition_on(
@@ -420,6 +425,8 @@ def extended_kalman_filter(
             "posterior_extras": {
                 "y_pred_mean": y_pred_mean,
                 "y_pred_cov": y_pred_cov,
+                "y_obs_pred_mean": y_obs_pred_mean,
+                "y_obs_pred_cov": y_obs_pred_cov,
             },
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
@@ -473,7 +480,8 @@ def iterated_extended_kalman_filter(
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 2).
         output_fields: list of top-level posterior fields to return.
-            `posterior_extras` stores per-step `y_pred_mean` and `y_pred_cov`.
+            `posterior_extras` stores both noiseless predictive emission
+            moments and data-facing predictive moments with observation noise.
         warn: whether to issue warnings during filtering (e.g., PSD issues).
     Returns:
         post: posterior object.

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -343,7 +343,10 @@ def ensemble_kalman_filter(
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to include in the output.
             `posterior_extras` stores filter-specific diagnostics including
-            `y_ens_pred`.
+            `y_ens_pred`. The innovation covariance `S` is the observation-
+            predictive covariance used for data scoring and assimilation,
+            corresponding to the ensemble predictive covariance plus the
+            observation covariance `R`.
         key: random generator key.
         warn: whether to warn about PSD issues.
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -208,6 +208,13 @@ def _condition_on(
     Returns:
         ll (float): log-likelihood of observation
         x_cond (N_particles, D_hid): filtered particles
+        dict containing:
+            - y_ens_pred: noiseless predictive observation ensemble
+            - y_obs_ens_pred: observation-predictive ensemble with sampled observation noise
+            - S: innovation covariance used for assimilation. This equals the
+              covariance of the predictive observation ensemble used in the
+              update, plus `R`. When inflation is enabled, that covariance is
+              computed from the inflated ensemble.
 
     """
 
@@ -232,6 +239,15 @@ def _condition_on(
         jnp.sum(_outer(y_ensemble - y_pred_mean, y_ensemble - y_pred_mean), axis=0)
         / (n_particles - 1),
         warn=warn,
+    )
+
+    # Observation-predictive ensemble obtained by adding observation noise.
+    key_obs_pred, key_assim = jr.split(key)
+    y_obs_ens_pred = y_ensemble + jr.multivariate_normal(
+        key=key_obs_pred,
+        mean=jnp.zeros_like(y_pred_mean),
+        cov=R,
+        shape=(n_particles,),
     )
 
     # Compute log-likelihood of observation based on Gaussian distribution,
@@ -274,7 +290,6 @@ def _condition_on(
         axis=0,
     ) / (n_particles - 1)
 
-    # Kalman gain
     S = y_pred_cov_infl + R
     K = psd_solve(S, cross_cov.T).T
 
@@ -282,7 +297,7 @@ def _condition_on(
     if perturb_measurements:
         # Add noise to the ensemble
         y_data_perturbed = jr.multivariate_normal(
-            key=key, mean=y, cov=R, shape=(n_particles,)
+            key=key_assim, mean=y, cov=R, shape=(n_particles,)
         )
     else:
         y_data_perturbed = y
@@ -302,6 +317,7 @@ def _condition_on(
         "loglik_step": ll_step,
         "x_cond": x_cond,
         "y_ens_pred": y_ensemble,
+        "y_obs_ens_pred": y_obs_ens_pred,
         "S": S,
         "K": K,
         "innovation": innovation,
@@ -343,10 +359,14 @@ def ensemble_kalman_filter(
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to include in the output.
             `posterior_extras` stores filter-specific diagnostics including
-            `y_ens_pred`. The innovation covariance `S` is the observation-
-            predictive covariance used for data scoring and assimilation,
-            corresponding to the ensemble predictive covariance plus the
-            observation covariance `R`.
+            `y_ens_pred` and `y_obs_ens_pred`. The latter adds sampled
+            observation noise to the predicted observation ensemble. The
+            innovation covariance `S` is the observation-predictive covariance
+            used for data scoring and assimilation:
+            `S = Cov(y_pred_update_ens) + R`, where `y_pred_update_ens` is the
+            predictive observation ensemble used in the update. When inflation
+            is enabled, this is the inflated ensemble rather than the raw
+            `y_ens_pred`.
         key: random generator key.
         warn: whether to warn about PSD issues.
 
@@ -450,6 +470,7 @@ def ensemble_kalman_filter(
             "x_ens_filtered": filtered_x_ens,
             "x_ens_predicted": pred_x_ens,
             "y_ens_pred": cond_dict["y_ens_pred"],
+            "y_obs_ens_pred": cond_dict["y_obs_ens_pred"],
             # Other diagnostics
             "loglik_step": cond_dict["loglik_step"],
             "S": cond_dict["S"],

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -301,6 +301,7 @@ def _condition_on(
     return {
         "loglik_step": ll_step,
         "x_cond": x_cond,
+        "y_ens_pred": y_ensemble,
         "S": S,
         "K": K,
         "innovation": innovation,
@@ -340,7 +341,9 @@ def ensemble_kalman_filter(
         t_emissions: continuous-time specific time instants of observations: if not None, it is an array
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
-        output_fields: list of fields to include in the output.
+        output_fields: list of top-level posterior fields to include in the output.
+            `posterior_extras` stores filter-specific diagnostics including
+            `y_ens_pred`.
         key: random generator key.
         warn: whether to warn about PSD issues.
 
@@ -443,6 +446,7 @@ def ensemble_kalman_filter(
             # Filtered/predicted particles here.
             "x_ens_filtered": filtered_x_ens,
             "x_ens_predicted": pred_x_ens,
+            "y_ens_pred": cond_dict["y_ens_pred"],
             # Other diagnostics
             "loglik_step": cond_dict["loglik_step"],
             "S": cond_dict["S"],

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -24,6 +24,7 @@ from cd_dynamax.dynamax.utils.utils import psd_solve
 # We import those posterior filtering and smoothing equivalent classes that can be reused from dynamax
 from cd_dynamax.dynamax.linear_gaussian_ssm.inference import (
     PosteriorGSSMFiltered,
+    validate_filtered_posterior_output_fields,
 )
 
 # Our codebase
@@ -42,6 +43,24 @@ from ..utils.debug_utils import psd, lax_scan
 tfb = tfp.bijectors
 
 DEBUG = False
+
+
+ENKF_FILTER_OUTPUT_FIELDS = (
+    "marginal_loglik",
+    "filtered_means",
+    "filtered_covariances",
+    "predicted_means",
+    "predicted_covariances",
+    "filtered_ensembles",
+    "predicted_ensembles",
+    "y_pred_mean",
+    "y_pred_cov",
+    "y_obs_pred_mean",
+    "y_obs_pred_cov",
+    "y_ens_pred",
+    "y_obs_ens_pred",
+    "posterior_extras",
+)
 
 #### Helper functions
 # Helper functions --- from dynamax
@@ -209,12 +228,13 @@ def _condition_on(
         ll (float): log-likelihood of observation
         x_cond (N_particles, D_hid): filtered particles
         dict containing:
-            - y_ens_pred: noiseless predictive observation ensemble
-            - y_obs_ens_pred: observation-predictive ensemble with sampled observation noise
-            - S: innovation covariance used for assimilation. This equals the
-              covariance of the predictive observation ensemble used in the
-              update, plus `R`. When inflation is enabled, that covariance is
-              computed from the inflated ensemble.
+            - y_ens_pred: noiseless predictive observation ensemble for observation time $t$, obtained from the prior ensemble approximating $x_{t|t-1}$
+            - y_obs_ens_pred: observation-predictive ensemble for observation time $t$, obtained by adding sampled observation noise to `y_ens_pred`
+            - S: innovation covariance used for assimilation and innovation-based
+              diagnostics. This equals the covariance of the predictive
+              observation ensemble used in the update, plus `R`. When
+              inflation is enabled, that covariance is computed from the
+              inflated ensemble.
 
     """
 
@@ -316,6 +336,10 @@ def _condition_on(
     return {
         "loglik_step": ll_step,
         "x_cond": x_cond,
+        "y_pred_mean": y_pred_mean,
+        "y_pred_cov": y_pred_cov,
+        "y_obs_pred_mean": y_pred_mean,
+        "y_obs_pred_cov": psd(y_pred_cov + R, warn=warn),
         "y_ens_pred": y_ensemble,
         "y_obs_ens_pred": y_obs_ens_pred,
         "S": S,
@@ -340,7 +364,6 @@ def ensemble_kalman_filter(
         "predicted_means",
         "predicted_covariances",
         "marginal_loglik",
-        "posterior_extras",
     ],
     key: PRNGKey = jr.PRNGKey(0),
     warn: bool = True,
@@ -358,15 +381,34 @@ def ensemble_kalman_filter(
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to include in the output.
-            `posterior_extras` stores filter-specific diagnostics including
-            `y_ens_pred` and `y_obs_ens_pred`. The latter adds sampled
-            observation noise to the predicted observation ensemble. The
-            innovation covariance `S` is the observation-predictive covariance
-            used for data scoring and assimilation:
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"` (default)
+            `"posterior_extras"`
+            `"filtered_ensembles"`
+            `"predicted_ensembles"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
+            `"y_ens_pred"`
+            `"y_obs_ens_pred"`
+            `y_pred_*` / `y_obs_pred_*` use the raw, non-inflated predictive
+            ensemble moments, while `y_obs_ens_pred` adds sampled
+            observation noise to `y_ens_pred`.
+            Note on `posterior_extras`:
+            `S` is the innovation covariance used for assimilation and
+            innovation-based diagnostics, with
             `S = Cov(y_pred_update_ens) + R`, where `y_pred_update_ens` is the
             predictive observation ensemble used in the update. When inflation
-            is enabled, this is the inflated ensemble rather than the raw
-            `y_ens_pred`.
+            is enabled, `S` is computed from the inflated ensemble rather than
+            the raw `y_ens_pred`, so `S` need not equal `y_obs_pred_cov`.
+            For data scoring, use `y_obs_pred_mean`, `y_obs_pred_cov`, and
+            `marginal_loglik`, which are computed from the raw, non-inflated
+            predictive moments.
         key: random generator key.
         warn: whether to warn about PSD issues.
 
@@ -374,6 +416,10 @@ def ensemble_kalman_filter(
         filtered_posterior: posterior object.
 
     """
+
+    validate_filtered_posterior_output_fields(
+        "ensemble_kalman_filter", output_fields, ENKF_FILTER_OUTPUT_FIELDS
+    )
 
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
@@ -466,12 +512,6 @@ def ensemble_kalman_filter(
 
         # EnKF extras
         posterior_extras = {
-            # Filtered/predicted particles here.
-            "x_ens_filtered": filtered_x_ens,
-            "x_ens_predicted": pred_x_ens,
-            "y_ens_pred": cond_dict["y_ens_pred"],
-            "y_obs_ens_pred": cond_dict["y_obs_ens_pred"],
-            # Other diagnostics
             "loglik_step": cond_dict["loglik_step"],
             "S": cond_dict["S"],
             "K": cond_dict["K"],
@@ -489,6 +529,14 @@ def ensemble_kalman_filter(
             "filtered_covariances": filtered_cov,
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
+            "filtered_ensembles": filtered_x_ens,
+            "predicted_ensembles": pred_x_ens,
+            "y_pred_mean": cond_dict["y_pred_mean"],
+            "y_pred_cov": cond_dict["y_pred_cov"],
+            "y_obs_pred_mean": cond_dict["y_obs_pred_mean"],
+            "y_obs_pred_cov": cond_dict["y_obs_pred_cov"],
+            "y_ens_pred": cond_dict["y_ens_pred"],
+            "y_obs_ens_pred": cond_dict["y_obs_ens_pred"],
             # Extras
             "posterior_extras": posterior_extras,
         }
@@ -548,7 +596,10 @@ def forecast_ensemble_kalman_filter(
         t_forecast: continuous-time specific time instants to forecast
         filter_hyperparams: hyper-parameters of the EnKF, related to the approximation order
         inputs: optional array of inputs.
-        output_fields: list of fields to return
+        output_fields: list of fields to return.
+            Options:
+            `"forecasted_state_means"` (default)
+            `"forecasted_state_covariances"` (default)
         key: random key.
         warn: whether to warn about PSD issues.
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
@@ -22,6 +22,7 @@ from cd_dynamax.dynamax.utils.utils import psd_solve
 # We import those posterior filtering and smoothing equivalent classes that can be reused from dynamax
 from cd_dynamax.dynamax.linear_gaussian_ssm.inference import (
     PosteriorGSSMFiltered,
+    validate_filtered_posterior_output_fields,
 )
 
 # Our codebase
@@ -40,6 +41,19 @@ from ..utils.debug_utils import psd, lax_scan
 tfb = tfp.bijectors
 
 DEBUG = False
+
+
+UKF_FILTER_OUTPUT_FIELDS = (
+    "marginal_loglik",
+    "filtered_means",
+    "filtered_covariances",
+    "predicted_means",
+    "predicted_covariances",
+    "y_pred_mean",
+    "y_pred_cov",
+    "y_obs_pred_mean",
+    "y_obs_pred_cov",
+)
 
 #### Helper functions
 # Helper functions --- from dynamax
@@ -318,10 +332,10 @@ def _condition_on(m, P, h, R, lamb, w_mean, w_cov, u, y, t, warn: bool = True):
         ll (float): log-likelihood of observation
         m_cond (D_hid,): filtered mean.
         P_cond (D_hid,D_hid): filtered covariance.
-        y_pred_mean (D_obs,): predictive emission mean before conditioning.
-        y_pred_cov (D_obs,D_obs): predictive emission covariance before adding R.
-        y_obs_pred_mean (D_obs,): predictive observation mean.
-        y_obs_pred_cov (D_obs,D_obs): predictive observation covariance including R.
+        y_pred_mean (D_obs,): predictive emission mean for observation time $t$ from $x_{t|t-1}$.
+        y_pred_cov (D_obs,D_obs): predictive emission covariance for observation time $t$ before adding $R$.
+        y_obs_pred_mean (D_obs,): predictive observation mean for $p(y_t \mid y_{1:t-1})$.
+        y_obs_pred_cov (D_obs,D_obs): predictive observation covariance for $p(y_t \mid y_{1:t-1})$, including $R$.
 
     """
     y_pred_mean, y_pred_cov, pred_cross = _emission_predicted_moments(
@@ -355,7 +369,6 @@ def unscented_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
-        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -372,16 +385,26 @@ def unscented_kalman_filter(
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to include in the output.
-            `posterior_extras` stores per-step noiseless predictive emission
-            moments `y_pred_mean` / `y_pred_cov`, and data-facing predictive
-            moments `y_obs_pred_mean` / `y_obs_pred_cov`, where
-            `y_obs_pred_cov = y_pred_cov + R`.
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"predicted_means"` (default)
+            `"predicted_covariances"` (default)
+            `"marginal_loglik"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
         warn: whether to issue warnings (e.g., about PSD issues)
 
     Returns:
         filtered_posterior: posterior object.
 
     """
+    validate_filtered_posterior_output_fields(
+        "unscented_kalman_filter", output_fields, UKF_FILTER_OUTPUT_FIELDS
+    )
+
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
     # t0 and t1 are num_timesteps \times 0
@@ -472,12 +495,10 @@ def unscented_kalman_filter(
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
             "marginal_loglik": ll,
-            "posterior_extras": {
-                "y_pred_mean": y_pred_mean,
-                "y_pred_cov": y_pred_cov,
-                "y_obs_pred_mean": y_obs_pred_mean,
-                "y_obs_pred_cov": y_obs_pred_cov,
-            },
+            "y_pred_mean": y_pred_mean,
+            "y_pred_cov": y_pred_cov,
+            "y_obs_pred_mean": y_obs_pred_mean,
+            "y_obs_pred_cov": y_obs_pred_cov,
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 
@@ -522,7 +543,10 @@ def forecast_unscented_kalman_filter(
         t_forecast: continuous-time specific time instants to forecast
         filter_hyperparams: hyper-parameters of the UKF, related to the approximation order
         inputs: optional array of inputs.
-        output_fields: list of fields to return
+        output_fields: list of fields to return.
+            Options:
+            `"forecasted_state_means"` (default)
+            `"forecasted_state_covariances"` (default)
         warn: whether to issue warnings (e.g., about PSD issues)
 
     Returns:

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
@@ -320,24 +320,27 @@ def _condition_on(m, P, h, R, lamb, w_mean, w_cov, u, y, t, warn: bool = True):
         P_cond (D_hid,D_hid): filtered covariance.
         y_pred_mean (D_obs,): predictive emission mean before conditioning.
         y_pred_cov (D_obs,D_obs): predictive emission covariance before adding R.
+        y_obs_pred_mean (D_obs,): predictive observation mean.
+        y_obs_pred_cov (D_obs,D_obs): predictive observation covariance including R.
 
     """
     y_pred_mean, y_pred_cov, pred_cross = _emission_predicted_moments(
         m, P, h, lamb, w_mean, w_cov, u, t, warn=warn
     )
-    pred_cov = psd(y_pred_cov + R, warn=warn)
+    y_obs_pred_mean = y_pred_mean
+    y_obs_pred_cov = psd(y_pred_cov + R, warn=warn)
 
     # Compute log-likelihood of observation based on Gaussian distribution,
     # using predicted mean and covariance
-    ll = MVN(y_pred_mean, pred_cov).log_prob(y)
+    ll = MVN(y_obs_pred_mean, y_obs_pred_cov).log_prob(y)
 
     # UKF gain
-    K = psd_solve(pred_cov, pred_cross.T).T
+    K = psd_solve(y_obs_pred_cov, pred_cross.T).T
     # Compute UKF filtered mean and covariance
     m_cond = m + K @ (y - y_pred_mean)
-    P_cond = psd(P - K @ pred_cov @ K.T, warn=warn)
+    P_cond = psd(P - K @ y_obs_pred_cov @ K.T, warn=warn)
     # Return log-likelihood, filtered mean/covariance, and predictive emission moments
-    return ll, m_cond, P_cond, y_pred_mean, y_pred_cov
+    return ll, m_cond, P_cond, y_pred_mean, y_pred_cov, y_obs_pred_mean, y_obs_pred_cov
 
 
 # UKF filtering main function
@@ -369,7 +372,10 @@ def unscented_kalman_filter(
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
         output_fields: list of top-level posterior fields to include in the output.
-            `posterior_extras` stores per-step `y_pred_mean` and `y_pred_cov`.
+            `posterior_extras` stores per-step noiseless predictive emission
+            moments `y_pred_mean` / `y_pred_cov`, and data-facing predictive
+            moments `y_obs_pred_mean` / `y_obs_pred_cov`, where
+            `y_obs_pred_cov = y_pred_cov + R`.
         warn: whether to issue warnings (e.g., about PSD issues)
 
     Returns:
@@ -427,10 +433,16 @@ def unscented_kalman_filter(
         R = params.emissions.emission_cov.f(None, u, t0)
 
         # Condition on this emission
-        log_likelihood, filtered_mean, filtered_cov, y_pred_mean, y_pred_cov = (
-            _condition_on(
-                pred_mean, pred_cov, h, R, lamb, w_mean, w_cov, u, y, t0, warn=warn
-            )
+        (
+            log_likelihood,
+            filtered_mean,
+            filtered_cov,
+            y_pred_mean,
+            y_pred_cov,
+            y_obs_pred_mean,
+            y_obs_pred_cov,
+        ) = _condition_on(
+            pred_mean, pred_cov, h, R, lamb, w_mean, w_cov, u, y, t0, warn=warn
         )
 
         # Update the log likelihood
@@ -463,6 +475,8 @@ def unscented_kalman_filter(
             "posterior_extras": {
                 "y_pred_mean": y_pred_mean,
                 "y_pred_cov": y_pred_cov,
+                "y_obs_pred_mean": y_obs_pred_mean,
+                "y_obs_pred_cov": y_obs_pred_cov,
             },
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_ukf.py
@@ -274,6 +274,29 @@ def _predict(
 
 
 # Condition on a new observation, under UKF approximations
+def _emission_predicted_moments(m, P, h, lamb, w_mean, w_cov, u, t, warn: bool = True):
+    """Compute the UKF Gaussian approximation to the predictive emission moments."""
+
+    n = len(m)
+    sigmas_cond = _compute_sigmas(m, P, n, lamb)
+    u_s = jnp.array([u] * len(sigmas_cond))
+    sigmas_cond_prop = vmap(h, in_axes=(0, None, None))(sigmas_cond, u_s, t)
+
+    y_pred_mean = jnp.tensordot(w_mean, sigmas_cond_prop, axes=1)
+    y_pred_cov = psd(
+        jnp.tensordot(
+            w_cov,
+            _outer(sigmas_cond_prop - y_pred_mean, sigmas_cond_prop - y_pred_mean),
+            axes=1,
+        ),
+        warn=warn,
+    )
+    pred_cross = jnp.tensordot(
+        w_cov, _outer(sigmas_cond - m, sigmas_cond_prop - y_pred_mean), axes=1
+    )
+    return y_pred_mean, y_pred_cov, pred_cross
+
+
 def _condition_on(m, P, h, R, lamb, w_mean, w_cov, u, y, t, warn: bool = True):
     """Condition a Gaussian potential on a new observation,
         using additive UKF approximations.
@@ -295,44 +318,26 @@ def _condition_on(m, P, h, R, lamb, w_mean, w_cov, u, y, t, warn: bool = True):
         ll (float): log-likelihood of observation
         m_cond (D_hid,): filtered mean.
         P_cond (D_hid,D_hid): filtered covariance.
+        y_pred_mean (D_obs,): predictive emission mean before conditioning.
+        y_pred_cov (D_obs,D_obs): predictive emission covariance before adding R.
 
     """
-    # Dimensions
-    n = len(m)
-
-    # Form sigma points and propagate
-    sigmas_cond = _compute_sigmas(m, P, n, lamb)
-    # Replicate inputs for each sigma point
-    u_s = jnp.array([u] * len(sigmas_cond))
-    # Propagate sigma points through emission function at time t with input u
-    sigmas_cond_prop = vmap(h, in_axes=(0, None, None))(sigmas_cond, u_s, t)
-
-    # Compute predicted mean, covariance, and cross-covariance
-    pred_mean = jnp.tensordot(w_mean, sigmas_cond_prop, axes=1)
-    pred_cov = psd(
-        R
-        + jnp.tensordot(
-            w_cov,
-            _outer(sigmas_cond_prop - pred_mean, sigmas_cond_prop - pred_mean),
-            axes=1,
-        ),
-        warn=warn,
+    y_pred_mean, y_pred_cov, pred_cross = _emission_predicted_moments(
+        m, P, h, lamb, w_mean, w_cov, u, t, warn=warn
     )
-    pred_cross = jnp.tensordot(
-        w_cov, _outer(sigmas_cond - m, sigmas_cond_prop - pred_mean), axes=1
-    )
+    pred_cov = psd(y_pred_cov + R, warn=warn)
 
     # Compute log-likelihood of observation based on Gaussian distribution,
     # using predicted mean and covariance
-    ll = MVN(pred_mean, pred_cov).log_prob(y)
+    ll = MVN(y_pred_mean, pred_cov).log_prob(y)
 
     # UKF gain
     K = psd_solve(pred_cov, pred_cross.T).T
     # Compute UKF filtered mean and covariance
-    m_cond = m + K @ (y - pred_mean)
+    m_cond = m + K @ (y - y_pred_mean)
     P_cond = psd(P - K @ pred_cov @ K.T, warn=warn)
-    # Return log-likelihood, filtered mean and covariance
-    return ll, m_cond, P_cond
+    # Return log-likelihood, filtered mean/covariance, and predictive emission moments
+    return ll, m_cond, P_cond, y_pred_mean, y_pred_cov
 
 
 # UKF filtering main function
@@ -347,6 +352,7 @@ def unscented_kalman_filter(
         "filtered_covariances",
         "predicted_means",
         "predicted_covariances",
+        "posterior_extras",
     ],
     warn: bool = True,
 ) -> PosteriorGSSMFiltered:
@@ -362,7 +368,8 @@ def unscented_kalman_filter(
         t_emissions: continuous-time specific time instants of observations: if not None, it is an array
         filter_hyperparams: hyper-parameters.
         inputs: optional array of inputs.
-        output_fields: list of fields to include in the output.
+        output_fields: list of top-level posterior fields to include in the output.
+            `posterior_extras` stores per-step `y_pred_mean` and `y_pred_cov`.
         warn: whether to issue warnings (e.g., about PSD issues)
 
     Returns:
@@ -420,8 +427,10 @@ def unscented_kalman_filter(
         R = params.emissions.emission_cov.f(None, u, t0)
 
         # Condition on this emission
-        log_likelihood, filtered_mean, filtered_cov = _condition_on(
-            pred_mean, pred_cov, h, R, lamb, w_mean, w_cov, u, y, t0, warn=warn
+        log_likelihood, filtered_mean, filtered_cov, y_pred_mean, y_pred_cov = (
+            _condition_on(
+                pred_mean, pred_cov, h, R, lamb, w_mean, w_cov, u, y, t0, warn=warn
+            )
         )
 
         # Update the log likelihood
@@ -451,6 +460,10 @@ def unscented_kalman_filter(
             "predicted_means": pred_mean,
             "predicted_covariances": pred_cov,
             "marginal_loglik": ll,
+            "posterior_extras": {
+                "y_pred_mean": y_pred_mean,
+                "y_pred_cov": y_pred_cov,
+            },
         }
         outputs = {key: val for key, val in outputs.items() if key in output_fields}
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
@@ -616,7 +616,12 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
         enkf_inflation_delta: float = 0.0,
         diffeqsolve_max_steps: int = 100,
         diffeqsolve_dt0: float = 1e-2,
-        output_fields=None,
+        output_fields=[
+            "filtered_means",
+            "filtered_covariances",
+            "predicted_means",
+            "predicted_covariances",
+        ],
         key=jr.PRNGKey(0),
         diffeqsolve_kwargs: Optional[dict] = {},
         extra_filter_kwargs: Optional[dict] = {},
@@ -640,8 +645,25 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
             output_fields: Which top-level posterior fields to return from the
-                filter. Include `"posterior_extras"` to keep filter-specific
-                diagnostics such as predictive emission moments.
+                filter. Predictive emission outputs and EnKF state-ensemble
+                outputs are available directly as top-level filtered posterior
+                fields. Options:
+                `"filtered_means"` (default for EKF/UKF/EnKF)
+                `"filtered_covariances"` (default for EKF/UKF/EnKF)
+                `"predicted_means"` (default for EKF/UKF/EnKF)
+                `"predicted_covariances"` (default for EKF/UKF/EnKF)
+                `"marginal_loglik"`
+                `"posterior_extras"`
+                `"filtered_ensembles"`
+                `"predicted_ensembles"`
+                `"y_pred_mean"`
+                `"y_pred_cov"`
+                `"y_obs_pred_mean"`
+                `"y_obs_pred_cov"`
+                `"y_ens_pred"`
+                `"y_obs_ens_pred"`
+                Filter-specific diagnostics remain in `"posterior_extras"`
+                when applicable. Unsupported fields raise a `ValueError`.
             key: Random number generator key.
             diffeqsolve_kwargs: Extra kwargs for the ODE solver
                 (e.g., {"solver": diffrax.Heun(), "dt0": 1e-2}).
@@ -1055,11 +1077,23 @@ def cdnlgssm_filter(
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 1).
         output_fields: list of top-level posterior fields to return.
-            These can include "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", "marginal_loglik",
-            and "posterior_extras". For EKF/UKF/EnKF, `posterior_extras`
-            contains filter-specific per-step diagnostics such as predictive
-            emission moments.
+            Defaults to `None`, which requests the defaults of the chosen
+            filter. Options:
+            `"filtered_means"` (default for EKF/UKF/EnKF)
+            `"filtered_covariances"` (default for EKF/UKF/EnKF)
+            `"predicted_means"` (default for EKF/UKF/EnKF)
+            `"predicted_covariances"` (default for EKF/UKF/EnKF)
+            `"marginal_loglik"` (default for EnKF)
+            `"posterior_extras"`
+            `"filtered_ensembles"`
+            `"predicted_ensembles"`
+            `"y_pred_mean"`
+            `"y_pred_cov"`
+            `"y_obs_pred_mean"`
+            `"y_obs_pred_cov"`
+            `"y_ens_pred"`
+            `"y_obs_ens_pred"`
+            Unsupported fields for the chosen filter raise a `ValueError`.
         key: random key (e.g., for EnKF).
         warn: whether to issue warnings during filtering.
 
@@ -1133,8 +1167,12 @@ def cdnlgssm_smoother(
         inputs: optional array of inputs.
         num_iter: optinal, number of linearizations around posterior for update step (default 1).
         output_fields: list of fields to return in posterior object.
-            These can take the values "filtered_means", "filtered_covariances",
-            "smoothed_means", "smoothed_covariances", and "marginal_loglik".
+            Options:
+            `"filtered_means"` (default)
+            `"filtered_covariances"` (default)
+            `"smoothed_means"` (default)
+            `"smoothed_covariances"` (default)
+            `"marginal_loglik"` (default)
         key: random key (e.g., for EnKS).
         warn: whether to issue warnings during smoothing (e.g., PSD issues).
 
@@ -1197,12 +1235,10 @@ def cdnlgssm_forecast(
         inputs: optional array of inputs, of shape (1 + num_timesteps) \times input_dim
             - The extra input is needed for the initial emission, i.e., it should be at time t_init
         output_fields: list of fields to return in posterior object.
-            These can take the values
-                If we forecast Gaussian distributions, based on filtering methods
-                    "forecasted_state_means",
-                    "forecasted_state_covariances",
-                If we forecast paths, based on solving the SDE
-                    "forecasted_state_path".
+            Options:
+            `"forecasted_state_means"` (default for Gaussian forecasts)
+            `"forecasted_state_covariances"` (default for Gaussian forecasts)
+            `"forecasted_state_path"` (for point-initialized path forecasts)
         key: random key (e.g., for Ensemble Kalman).
         diffeqsolve_settings: settings for the SDE solver
         warn: whether to issue warnings during forecasting (e.g., PSD issues).

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
@@ -639,7 +639,9 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
             enkf_inflation_delta: EnKF covariance inflation (ignored by EKF/UKF).
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
-            output_fields: Which fields to return from the filter.
+            output_fields: Which top-level posterior fields to return from the
+                filter. Include `"posterior_extras"` to keep filter-specific
+                diagnostics such as predictive emission moments.
             key: Random number generator key.
             diffeqsolve_kwargs: Extra kwargs for the ODE solver
                 (e.g., {"solver": diffrax.Heun(), "dt0": 1e-2}).
@@ -1052,9 +1054,12 @@ def cdnlgssm_filter(
         filter_hyperparams: hyper-parameters of the filter
         inputs: optional array of inputs.
         num_iter: number of linearizations around posterior for update step (default 1).
-        output_fields: list of fields to return in posterior object.
-            These can take the values "filtered_means", "filtered_covariances",
-            "predicted_means", "predicted_covariances", and "marginal_loglik".
+        output_fields: list of top-level posterior fields to return.
+            These can include "filtered_means", "filtered_covariances",
+            "predicted_means", "predicted_covariances", "marginal_loglik",
+            and "posterior_extras". For EKF/UKF/EnKF, `posterior_extras`
+            contains filter-specific per-step diagnostics such as predictive
+            emission moments.
         key: random key (e.g., for EnKF).
         warn: whether to issue warnings during filtering.
 

--- a/cd_dynamax/src/continuous_discrete_nonlinear_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_ssm/models.py
@@ -491,6 +491,13 @@ class ContDiscreteNonlinearSSM(SSM):
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
             output_fields: Which fields to return from the filter.
+                Defaults to `None`. This argument is currently ignored by
+                `cdnlssm_filter`. Always returned:
+                `"filtered_means"`
+                `"filtered_covariances"`
+                `"particles"`
+                `"log_weights"`
+                `"marginal_loglik"`
             key: Random key.
             diffeqsolve_kwargs: Extra kwargs for the ODE solver
                 (e.g., {"solver": diffrax.Heun(), "dt0": 1e-2}).
@@ -562,6 +569,10 @@ class ContDiscreteNonlinearSSM(SSM):
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
             output_fields: Which fields to return from the filter.
+                Defaults to `None`. This argument is currently ignored by
+                `cdnlssm_filter`, which always returns
+                `"filtered_means"`, `"filtered_covariances"`, `"particles"`,
+                `"log_weights"`, and `"marginal_loglik"`.
             key: Random key.
             diffeqsolve_kwargs: Extra kwargs for the ODE solver
                 (e.g., {"solver": diffrax.Heun(), "dt0": 1e-2}).
@@ -711,6 +722,13 @@ def cdnlssm_filter(
         filter_hyperparams: Hyperparameters of the filter.
         inputs: Inputs.
         output_fields: Fields to return.
+            Defaults to `None`. This argument is currently ignored; the
+            returned posterior always includes:
+            `"filtered_means"`
+            `"filtered_covariances"`
+            `"particles"`
+            `"log_weights"`
+            `"marginal_loglik"`
         key: Random key.
         warn: Whether to warn.
 

--- a/cd_dynamax/src/utils/demo_utils.py
+++ b/cd_dynamax/src/utils/demo_utils.py
@@ -376,8 +376,8 @@ def plot_drift_field(
 
 def plot_particle_diagnostics(
     t_emissions,  # shape (T,) time vector
-    x_ens_filtered,  # shape (T, N, D) ensemble after update
-    x_ens_predicted,  # shape (T, N, D) ensemble before update (forecast)
+    filtered_ensembles,  # shape (T, N, D) ensemble after update
+    predicted_ensembles,  # shape (T, N, D) ensemble before update (forecast)
     observations,  # shape (T, D_obs) -- assume D_obs == D for now
     start_idx=0,
     stop_idx=None,
@@ -389,14 +389,14 @@ def plot_particle_diagnostics(
 
     Args:
         t_emissions: (T,) time vector
-        x_ens_filtered: (T, N, D) ensemble after update
-        x_ens_predicted: (T, N, D) ensemble before update (forecast)
+        filtered_ensembles: (T, N, D) ensemble after update
+        predicted_ensembles: (T, N, D) ensemble before update (forecast)
         observations: (T, D) true observations
         start_idx: int, start timestep
         stop_idx: int, stop timestep (exclusive)
         figsize: tuple, figure size
     """
-    T, N, D = x_ens_filtered.shape
+    T, N, D = filtered_ensembles.shape
     if stop_idx is None:
         stop_idx = T
 
@@ -423,8 +423,8 @@ def plot_particle_diagnostics(
             t0 = t_emissions[t]
             t1 = t_emissions[t + 1]
 
-            xf = x_ens_filtered[t, :, d]
-            xp = x_ens_predicted[t + 1, :, d]
+            xf = filtered_ensembles[t, :, d]
+            xp = predicted_ensembles[t + 1, :, d]
 
             ax.scatter(
                 np.full(N, t0),

--- a/tests/test_linear_gaussian_filter_posterior_extras.py
+++ b/tests/test_linear_gaussian_filter_posterior_extras.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import pytest
 
 from cd_dynamax import (
     ContDiscreteLinearGaussianSSM,
@@ -15,7 +16,7 @@ def _make_test_problem():
     return model, params, emissions, t_emissions
 
 
-def test_cdlgssm_filter_posterior_extras_match_predictive_state_moments():
+def test_cdlgssm_filter_predictive_observation_fields_match_predictive_state_moments():
     _, params, emissions, t_emissions = _make_test_problem()
     H = params.emissions.weights
     D = (
@@ -39,36 +40,37 @@ def test_cdlgssm_filter_posterior_extras_match_predictive_state_moments():
         output_fields=[
             "predicted_means",
             "predicted_covariances",
-            "posterior_extras",
+            "y_pred_mean",
+            "y_pred_cov",
+            "y_obs_pred_mean",
+            "y_obs_pred_cov",
         ],
         warn=False,
     )
 
-    extras = posterior.posterior_extras
-    assert extras is not None
-    assert extras["y_pred_mean"].shape == (3, 1)
-    assert extras["y_pred_cov"].shape == (3, 1, 1)
-    assert extras["y_obs_pred_mean"].shape == (3, 1)
-    assert extras["y_obs_pred_cov"].shape == (3, 1, 1)
-    assert jnp.all(jnp.isfinite(extras["y_pred_mean"]))
-    assert jnp.all(jnp.isfinite(extras["y_pred_cov"]))
-    assert jnp.all(jnp.isfinite(extras["y_obs_pred_mean"]))
-    assert jnp.all(jnp.isfinite(extras["y_obs_pred_cov"]))
+    assert posterior.y_pred_mean.shape == (3, 1)
+    assert posterior.y_pred_cov.shape == (3, 1, 1)
+    assert posterior.y_obs_pred_mean.shape == (3, 1)
+    assert posterior.y_obs_pred_cov.shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(posterior.y_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_pred_cov))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_cov))
 
-    assert jnp.allclose(extras["y_pred_mean"][0], H @ params.initial.mean + D @ u + d)
-    assert jnp.allclose(extras["y_pred_cov"][0], H @ params.initial.cov @ H.T)
-    assert jnp.allclose(extras["y_obs_pred_mean"], extras["y_pred_mean"])
-    assert jnp.allclose(extras["y_obs_pred_cov"], extras["y_pred_cov"] + R)
+    assert jnp.allclose(posterior.y_pred_mean[0], H @ params.initial.mean + D @ u + d)
+    assert jnp.allclose(posterior.y_pred_cov[0], H @ params.initial.cov @ H.T)
+    assert jnp.allclose(posterior.y_obs_pred_mean, posterior.y_pred_mean)
+    assert jnp.allclose(posterior.y_obs_pred_cov, posterior.y_pred_cov + R)
     assert jnp.allclose(
-        extras["y_pred_mean"][1:], posterior.predicted_means[:-1] @ H.T + D @ u + d
+        posterior.y_pred_mean[1:], posterior.predicted_means[:-1] @ H.T + D @ u + d
     )
     assert jnp.allclose(
-        extras["y_pred_cov"][1:],
+        posterior.y_pred_cov[1:],
         jnp.einsum("ij,tjk,kl->til", H, posterior.predicted_covariances[:-1], H.T),
     )
 
 
-def test_linear_model_filter_can_return_only_posterior_extras():
+def test_linear_model_filter_can_return_only_predictive_observation_field():
     model, params, emissions, t_emissions = _make_test_problem()
 
     posterior = model.filter(
@@ -76,13 +78,30 @@ def test_linear_model_filter_can_return_only_posterior_extras():
         emissions=emissions,
         t_emissions=t_emissions,
         filter_hyperparams=KFHyperParams(),
-        output_fields=["posterior_extras"],
+        output_fields=["y_pred_mean"],
         warn=False,
     )
 
-    assert posterior.posterior_extras is not None
+    assert posterior.y_pred_mean is not None
     assert posterior.filtered_means is None
     assert posterior.filtered_covariances is None
     assert posterior.predicted_means is None
     assert posterior.predicted_covariances is None
+    assert posterior.y_pred_cov is None
+    assert posterior.y_obs_pred_mean is None
+    assert posterior.y_obs_pred_cov is None
     assert jnp.isfinite(posterior.marginal_loglik)
+
+
+def test_linear_filter_rejects_unsupported_output_field():
+    _, params, emissions, t_emissions = _make_test_problem()
+
+    with pytest.raises(ValueError, match="cdlgssm_filter"):
+        cdlgssm_filter(
+            params=params,
+            emissions=emissions,
+            t_emissions=t_emissions,
+            filter_hyperparams=KFHyperParams(),
+            output_fields=["y_ens_pred"],
+            warn=False,
+        )

--- a/tests/test_linear_gaussian_filter_posterior_extras.py
+++ b/tests/test_linear_gaussian_filter_posterior_extras.py
@@ -1,0 +1,88 @@
+import jax.numpy as jnp
+
+from cd_dynamax import (
+    ContDiscreteLinearGaussianSSM,
+    KFHyperParams,
+    cdlgssm_filter,
+)
+
+
+def _make_test_problem():
+    model = ContDiscreteLinearGaussianSSM(state_dim=1, emission_dim=1)
+    params, _ = model.initialize()
+    emissions = jnp.zeros((3, 1))
+    t_emissions = jnp.array([[0.0], [0.1], [0.2]])
+    return model, params, emissions, t_emissions
+
+
+def test_cdlgssm_filter_posterior_extras_match_predictive_state_moments():
+    _, params, emissions, t_emissions = _make_test_problem()
+    H = params.emissions.weights
+    D = (
+        params.emissions.input_weights
+        if params.emissions.input_weights is not None
+        else jnp.zeros((H.shape[0], 0))
+    )
+    d = (
+        params.emissions.bias
+        if params.emissions.bias is not None
+        else jnp.zeros((H.shape[0],))
+    )
+    u = jnp.zeros((D.shape[1],))
+    R = params.emissions.cov
+
+    posterior = cdlgssm_filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=KFHyperParams(),
+        output_fields=[
+            "predicted_means",
+            "predicted_covariances",
+            "posterior_extras",
+        ],
+        warn=False,
+    )
+
+    extras = posterior.posterior_extras
+    assert extras is not None
+    assert extras["y_pred_mean"].shape == (3, 1)
+    assert extras["y_pred_cov"].shape == (3, 1, 1)
+    assert extras["y_obs_pred_mean"].shape == (3, 1)
+    assert extras["y_obs_pred_cov"].shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(extras["y_pred_mean"]))
+    assert jnp.all(jnp.isfinite(extras["y_pred_cov"]))
+    assert jnp.all(jnp.isfinite(extras["y_obs_pred_mean"]))
+    assert jnp.all(jnp.isfinite(extras["y_obs_pred_cov"]))
+
+    assert jnp.allclose(extras["y_pred_mean"][0], H @ params.initial.mean + D @ u + d)
+    assert jnp.allclose(extras["y_pred_cov"][0], H @ params.initial.cov @ H.T)
+    assert jnp.allclose(extras["y_obs_pred_mean"], extras["y_pred_mean"])
+    assert jnp.allclose(extras["y_obs_pred_cov"], extras["y_pred_cov"] + R)
+    assert jnp.allclose(
+        extras["y_pred_mean"][1:], posterior.predicted_means[:-1] @ H.T + D @ u + d
+    )
+    assert jnp.allclose(
+        extras["y_pred_cov"][1:],
+        jnp.einsum("ij,tjk,kl->til", H, posterior.predicted_covariances[:-1], H.T),
+    )
+
+
+def test_linear_model_filter_can_return_only_posterior_extras():
+    model, params, emissions, t_emissions = _make_test_problem()
+
+    posterior = model.filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=KFHyperParams(),
+        output_fields=["posterior_extras"],
+        warn=False,
+    )
+
+    assert posterior.posterior_extras is not None
+    assert posterior.filtered_means is None
+    assert posterior.filtered_covariances is None
+    assert posterior.predicted_means is None
+    assert posterior.predicted_covariances is None
+    assert jnp.isfinite(posterior.marginal_loglik)

--- a/tests/test_nonlinear_gaussian_filter_posterior_extras.py
+++ b/tests/test_nonlinear_gaussian_filter_posterior_extras.py
@@ -28,20 +28,24 @@ def _make_test_problem():
     return params, emissions, t_emissions
 
 
-def _ensemble_covariance(ensemble):
-    centered = ensemble - jnp.mean(ensemble, axis=1, keepdims=True)
-    return jnp.einsum("tni,tnj->tij", centered, centered) / (ensemble.shape[1] - 1)
-
-
 @pytest.mark.parametrize(
-    "filter_hyperparams",
+    ("filter_hyperparams", "output_field"),
     [
-        EKFHyperParams(state_order="first"),
-        UKFHyperParams(state_order="first"),
-        EnKFHyperParams(N_particles=8, perturb_measurements=False),
+        (EKFHyperParams(state_order="first"), "y_pred_mean"),
+        (UKFHyperParams(state_order="first"), "y_obs_pred_cov"),
+        (
+            EnKFHyperParams(N_particles=8, perturb_measurements=False),
+            "y_obs_pred_cov",
+        ),
+        (
+            EnKFHyperParams(N_particles=8, perturb_measurements=False),
+            "predicted_ensembles",
+        ),
     ],
 )
-def test_cdnlgssm_filter_can_return_only_posterior_extras(filter_hyperparams):
+def test_cdnlgssm_filter_can_return_only_requested_predictive_field(
+    filter_hyperparams, output_field
+):
     params, emissions, t_emissions = _make_test_problem()
 
     posterior = cdnlgssm_filter(
@@ -49,12 +53,12 @@ def test_cdnlgssm_filter_can_return_only_posterior_extras(filter_hyperparams):
         emissions=emissions,
         t_emissions=t_emissions,
         filter_hyperparams=filter_hyperparams,
-        output_fields=["posterior_extras"],
+        output_fields=[output_field],
         key=jr.PRNGKey(0),
         warn=False,
     )
 
-    assert posterior.posterior_extras is not None
+    assert getattr(posterior, output_field) is not None
     assert posterior.filtered_means is None
     assert posterior.filtered_covariances is None
     assert posterior.predicted_means is None
@@ -69,7 +73,7 @@ def test_cdnlgssm_filter_can_return_only_posterior_extras(filter_hyperparams):
         (unscented_kalman_filter, UKFHyperParams(state_order="first")),
     ],
 )
-def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
+def test_ekf_and_ukf_predictive_observation_fields_match_predictive_state_moments(
     filter_fn, filter_hyperparams
 ):
     params, emissions, t_emissions = _make_test_problem()
@@ -83,31 +87,32 @@ def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
         output_fields=[
             "predicted_means",
             "predicted_covariances",
-            "posterior_extras",
+            "y_pred_mean",
+            "y_pred_cov",
+            "y_obs_pred_mean",
+            "y_obs_pred_cov",
         ],
         warn=False,
     )
 
-    extras = posterior.posterior_extras
-    assert extras is not None
-    assert extras["y_pred_mean"].shape == (3, 1)
-    assert extras["y_pred_cov"].shape == (3, 1, 1)
-    assert extras["y_obs_pred_mean"].shape == (3, 1)
-    assert extras["y_obs_pred_cov"].shape == (3, 1, 1)
-    assert jnp.all(jnp.isfinite(extras["y_pred_mean"]))
-    assert jnp.all(jnp.isfinite(extras["y_pred_cov"]))
-    assert jnp.all(jnp.isfinite(extras["y_obs_pred_mean"]))
-    assert jnp.all(jnp.isfinite(extras["y_obs_pred_cov"]))
+    assert posterior.y_pred_mean.shape == (3, 1)
+    assert posterior.y_pred_cov.shape == (3, 1, 1)
+    assert posterior.y_obs_pred_mean.shape == (3, 1)
+    assert posterior.y_obs_pred_cov.shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(posterior.y_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_pred_cov))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_cov))
 
-    assert jnp.allclose(extras["y_pred_mean"][0], params.initial.mean.f())
-    assert jnp.allclose(extras["y_pred_cov"][0], params.initial.cov.f())
-    assert jnp.allclose(extras["y_obs_pred_mean"], extras["y_pred_mean"])
-    assert jnp.allclose(extras["y_obs_pred_cov"], extras["y_pred_cov"] + R)
-    assert jnp.allclose(extras["y_pred_mean"][1:], posterior.predicted_means[:-1])
-    assert jnp.allclose(extras["y_pred_cov"][1:], posterior.predicted_covariances[:-1])
+    assert jnp.allclose(posterior.y_pred_mean[0], params.initial.mean.f())
+    assert jnp.allclose(posterior.y_pred_cov[0], params.initial.cov.f())
+    assert jnp.allclose(posterior.y_obs_pred_mean, posterior.y_pred_mean)
+    assert jnp.allclose(posterior.y_obs_pred_cov, posterior.y_pred_cov + R)
+    assert jnp.allclose(posterior.y_pred_mean[1:], posterior.predicted_means[:-1])
+    assert jnp.allclose(posterior.y_pred_cov[1:], posterior.predicted_covariances[:-1])
 
 
-def test_enkf_posterior_extras_include_predictive_emission_ensemble():
+def test_enkf_predictive_observation_ensembles_are_top_level_outputs():
     params, emissions, t_emissions = _make_test_problem()
     n_particles = 64
 
@@ -119,21 +124,114 @@ def test_enkf_posterior_extras_include_predictive_emission_ensemble():
             N_particles=n_particles, perturb_measurements=False
         ),
         output_fields=[
+            "filtered_ensembles",
+            "predicted_ensembles",
             "predicted_means",
             "predicted_covariances",
+            "y_ens_pred",
+            "y_obs_ens_pred",
             "posterior_extras",
         ],
         key=jr.PRNGKey(0),
         warn=False,
     )
 
-    extras = posterior.posterior_extras
-    assert extras is not None
-    assert extras["y_ens_pred"].shape == (3, n_particles, 1)
-    assert extras["y_obs_ens_pred"].shape == (3, n_particles, 1)
-    assert extras["x_ens_predicted"].shape == (3, n_particles, 1)
-    assert extras["S"].shape == (3, 1, 1)
-    assert jnp.all(jnp.isfinite(extras["y_ens_pred"]))
-    assert jnp.all(jnp.isfinite(extras["y_obs_ens_pred"]))
-    assert jnp.all(jnp.isfinite(extras["S"]))
-    assert jnp.any(jnp.abs(extras["y_obs_ens_pred"] - extras["y_ens_pred"]) > 1e-6)
+    assert posterior.filtered_ensembles.shape == (3, n_particles, 1)
+    assert posterior.predicted_ensembles.shape == (3, n_particles, 1)
+    assert posterior.y_ens_pred.shape == (3, n_particles, 1)
+    assert posterior.y_obs_ens_pred.shape == (3, n_particles, 1)
+    assert posterior.posterior_extras is not None
+    assert "x_ens_filtered" not in posterior.posterior_extras
+    assert "x_ens_predicted" not in posterior.posterior_extras
+    assert posterior.posterior_extras["S"].shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(posterior.filtered_ensembles))
+    assert jnp.all(jnp.isfinite(posterior.predicted_ensembles))
+    assert jnp.all(jnp.isfinite(posterior.y_ens_pred))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_ens_pred))
+    assert jnp.all(jnp.isfinite(posterior.posterior_extras["S"]))
+    assert jnp.any(jnp.abs(posterior.y_obs_ens_pred - posterior.y_ens_pred) > 1e-6)
+
+
+def test_enkf_predictive_observation_moments_are_top_level_outputs():
+    params, emissions, t_emissions = _make_test_problem()
+    R = params.emissions.emission_cov.f(None, None, None)
+
+    posterior = ensemble_kalman_filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=EnKFHyperParams(N_particles=64, perturb_measurements=False),
+        output_fields=[
+            "y_pred_mean",
+            "y_pred_cov",
+            "y_obs_pred_mean",
+            "y_obs_pred_cov",
+        ],
+        key=jr.PRNGKey(0),
+        warn=False,
+    )
+
+    assert posterior.y_pred_mean.shape == (3, 1)
+    assert posterior.y_pred_cov.shape == (3, 1, 1)
+    assert posterior.y_obs_pred_mean.shape == (3, 1)
+    assert posterior.y_obs_pred_cov.shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(posterior.y_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_pred_cov))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_mean))
+    assert jnp.all(jnp.isfinite(posterior.y_obs_pred_cov))
+    assert jnp.allclose(posterior.y_obs_pred_mean, posterior.y_pred_mean)
+    assert jnp.allclose(posterior.y_obs_pred_cov, posterior.y_pred_cov + R)
+
+
+def test_enkf_posterior_extras_are_not_returned_by_default():
+    params, emissions, t_emissions = _make_test_problem()
+
+    posterior = ensemble_kalman_filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=EnKFHyperParams(N_particles=16, perturb_measurements=False),
+        key=jr.PRNGKey(0),
+        warn=False,
+    )
+
+    assert posterior.posterior_extras is None
+    assert posterior.filtered_means is not None
+    assert posterior.predicted_means is not None
+    assert jnp.isfinite(posterior.marginal_loglik)
+
+
+@pytest.mark.parametrize(
+    ("filter_fn", "filter_hyperparams", "output_field", "filter_name"),
+    [
+        (
+            extended_kalman_filter,
+            EKFHyperParams(state_order="first"),
+            "y_ens_pred",
+            "extended_kalman_filter",
+        ),
+        (
+            unscented_kalman_filter,
+            UKFHyperParams(state_order="first"),
+            "y_obs_ens_pred",
+            "unscented_kalman_filter",
+        ),
+    ],
+)
+def test_filters_reject_unsupported_predictive_output_fields(
+    filter_fn, filter_hyperparams, output_field, filter_name
+):
+    params, emissions, t_emissions = _make_test_problem()
+
+    with pytest.raises(ValueError, match=filter_name):
+        kwargs = dict(
+            params=params,
+            emissions=emissions,
+            t_emissions=t_emissions,
+            filter_hyperparams=filter_hyperparams,
+            output_fields=[output_field],
+            warn=False,
+        )
+        if filter_name == "ensemble_kalman_filter":
+            kwargs["key"] = jr.PRNGKey(0)
+        filter_fn(**kwargs)

--- a/tests/test_nonlinear_gaussian_filter_posterior_extras.py
+++ b/tests/test_nonlinear_gaussian_filter_posterior_extras.py
@@ -109,7 +109,7 @@ def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
 
 def test_enkf_posterior_extras_include_predictive_emission_ensemble():
     params, emissions, t_emissions = _make_test_problem()
-    n_particles = 8
+    n_particles = 64
 
     posterior = ensemble_kalman_filter(
         params=params,
@@ -130,12 +130,10 @@ def test_enkf_posterior_extras_include_predictive_emission_ensemble():
     extras = posterior.posterior_extras
     assert extras is not None
     assert extras["y_ens_pred"].shape == (3, n_particles, 1)
+    assert extras["y_obs_ens_pred"].shape == (3, n_particles, 1)
     assert extras["x_ens_predicted"].shape == (3, n_particles, 1)
+    assert extras["S"].shape == (3, 1, 1)
     assert jnp.all(jnp.isfinite(extras["y_ens_pred"]))
-
-    expected_mean = jnp.mean(extras["y_ens_pred"], axis=1)
-    expected_cov = _ensemble_covariance(extras["y_ens_pred"])
-    assert jnp.allclose(expected_mean[1:], posterior.predicted_means[:-1])
-    assert jnp.allclose(expected_cov[1:], posterior.predicted_covariances[:-1])
-
-    assert jnp.allclose(extras["y_ens_pred"][1:], extras["x_ens_predicted"][:-1])
+    assert jnp.all(jnp.isfinite(extras["y_obs_ens_pred"]))
+    assert jnp.all(jnp.isfinite(extras["S"]))
+    assert jnp.any(jnp.abs(extras["y_obs_ens_pred"] - extras["y_ens_pred"]) > 1e-6)

--- a/tests/test_nonlinear_gaussian_filter_posterior_extras.py
+++ b/tests/test_nonlinear_gaussian_filter_posterior_extras.py
@@ -1,0 +1,134 @@
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm import (
+    ContDiscreteNonlinearGaussianSSM,
+    EKFHyperParams,
+    EnKFHyperParams,
+    UKFHyperParams,
+    cdnlgssm_filter,
+)
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_ekf import (
+    extended_kalman_filter,
+)
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_enkf import (
+    ensemble_kalman_filter,
+)
+from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_ukf import (
+    unscented_kalman_filter,
+)
+
+
+def _make_test_problem():
+    model = ContDiscreteNonlinearGaussianSSM(state_dim=1, emission_dim=1)
+    params, _ = model.initialize()
+    emissions = jnp.zeros((3, 1))
+    t_emissions = jnp.array([[0.0], [0.1], [0.2]])
+    return params, emissions, t_emissions
+
+
+def _ensemble_covariance(ensemble):
+    centered = ensemble - jnp.mean(ensemble, axis=1, keepdims=True)
+    return jnp.einsum("tni,tnj->tij", centered, centered) / (ensemble.shape[1] - 1)
+
+
+@pytest.mark.parametrize(
+    "filter_hyperparams",
+    [
+        EKFHyperParams(state_order="first"),
+        UKFHyperParams(state_order="first"),
+        EnKFHyperParams(N_particles=8, perturb_measurements=False),
+    ],
+)
+def test_cdnlgssm_filter_can_return_only_posterior_extras(filter_hyperparams):
+    params, emissions, t_emissions = _make_test_problem()
+
+    posterior = cdnlgssm_filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=filter_hyperparams,
+        output_fields=["posterior_extras"],
+        key=jr.PRNGKey(0),
+        warn=False,
+    )
+
+    assert posterior.posterior_extras is not None
+    assert posterior.filtered_means is None
+    assert posterior.filtered_covariances is None
+    assert posterior.predicted_means is None
+    assert posterior.predicted_covariances is None
+    assert jnp.isfinite(posterior.marginal_loglik)
+
+
+@pytest.mark.parametrize(
+    ("filter_fn", "filter_hyperparams"),
+    [
+        (extended_kalman_filter, EKFHyperParams(state_order="first")),
+        (unscented_kalman_filter, UKFHyperParams(state_order="first")),
+    ],
+)
+def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
+    filter_fn, filter_hyperparams
+):
+    params, emissions, t_emissions = _make_test_problem()
+
+    posterior = filter_fn(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=filter_hyperparams,
+        output_fields=[
+            "predicted_means",
+            "predicted_covariances",
+            "posterior_extras",
+        ],
+        warn=False,
+    )
+
+    extras = posterior.posterior_extras
+    assert extras is not None
+    assert extras["y_pred_mean"].shape == (3, 1)
+    assert extras["y_pred_cov"].shape == (3, 1, 1)
+    assert jnp.all(jnp.isfinite(extras["y_pred_mean"]))
+    assert jnp.all(jnp.isfinite(extras["y_pred_cov"]))
+
+    assert jnp.allclose(extras["y_pred_mean"][0], params.initial.mean.f())
+    assert jnp.allclose(extras["y_pred_cov"][0], params.initial.cov.f())
+    assert jnp.allclose(extras["y_pred_mean"][1:], posterior.predicted_means[:-1])
+    assert jnp.allclose(extras["y_pred_cov"][1:], posterior.predicted_covariances[:-1])
+
+
+def test_enkf_posterior_extras_include_predictive_emission_ensemble():
+    params, emissions, t_emissions = _make_test_problem()
+    n_particles = 8
+
+    posterior = ensemble_kalman_filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=EnKFHyperParams(
+            N_particles=n_particles, perturb_measurements=False
+        ),
+        output_fields=[
+            "predicted_means",
+            "predicted_covariances",
+            "posterior_extras",
+        ],
+        key=jr.PRNGKey(0),
+        warn=False,
+    )
+
+    extras = posterior.posterior_extras
+    assert extras is not None
+    assert extras["y_ens_pred"].shape == (3, n_particles, 1)
+    assert extras["x_ens_predicted"].shape == (3, n_particles, 1)
+    assert jnp.all(jnp.isfinite(extras["y_ens_pred"]))
+
+    expected_mean = jnp.mean(extras["y_ens_pred"], axis=1)
+    expected_cov = _ensemble_covariance(extras["y_ens_pred"])
+    assert jnp.allclose(expected_mean[1:], posterior.predicted_means[:-1])
+    assert jnp.allclose(expected_cov[1:], posterior.predicted_covariances[:-1])
+
+    assert jnp.allclose(extras["y_ens_pred"][1:], extras["x_ens_predicted"][:-1])

--- a/tests/test_nonlinear_gaussian_filter_posterior_extras.py
+++ b/tests/test_nonlinear_gaussian_filter_posterior_extras.py
@@ -73,6 +73,7 @@ def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
     filter_fn, filter_hyperparams
 ):
     params, emissions, t_emissions = _make_test_problem()
+    R = params.emissions.emission_cov.f(None, None, None)
 
     posterior = filter_fn(
         params=params,
@@ -91,11 +92,17 @@ def test_ekf_and_ukf_posterior_extras_match_predictive_state_moments(
     assert extras is not None
     assert extras["y_pred_mean"].shape == (3, 1)
     assert extras["y_pred_cov"].shape == (3, 1, 1)
+    assert extras["y_obs_pred_mean"].shape == (3, 1)
+    assert extras["y_obs_pred_cov"].shape == (3, 1, 1)
     assert jnp.all(jnp.isfinite(extras["y_pred_mean"]))
     assert jnp.all(jnp.isfinite(extras["y_pred_cov"]))
+    assert jnp.all(jnp.isfinite(extras["y_obs_pred_mean"]))
+    assert jnp.all(jnp.isfinite(extras["y_obs_pred_cov"]))
 
     assert jnp.allclose(extras["y_pred_mean"][0], params.initial.mean.f())
     assert jnp.allclose(extras["y_pred_cov"][0], params.initial.cov.f())
+    assert jnp.allclose(extras["y_obs_pred_mean"], extras["y_pred_mean"])
+    assert jnp.allclose(extras["y_obs_pred_cov"], extras["y_pred_cov"] + R)
     assert jnp.allclose(extras["y_pred_mean"][1:], posterior.predicted_means[:-1])
     assert jnp.allclose(extras["y_pred_cov"][1:], posterior.predicted_covariances[:-1])
 


### PR DESCRIPTION
## Summary

This PR adds predictive emission information to the continuous-discrete Gaussian filters so downstream code can evaluate both latent signal uncertainty and observation-level uncertainty from filter outputs.

Why? We want to evaluate filters using scoring rules that compare predicted observation distributions versus the observed data; this will allow us to not only evaluate, but also tune filters w.r.t. various metrics.

Specifically:

- `KF`, `EKF`, `UKF`, and `EnKF` now return predictive emission fields in `posterior_extras`
- filter docstrings were cleaned up around `output_fields` and predictive output semantics
- regression tests were added for the new outputs

## External dependency
There is an [open Dynestyx PR](https://github.com/BasisResearch/dynestyx/issues/258) for filter-scoring that relies on this PR here.

## What’s included

### KF / EKF / UKF

These filters now expose both of the following in `posterior_extras`:

- `y_pred_mean`
- `y_pred_cov`
- `y_obs_pred_mean`
- `y_obs_pred_cov`

The intended distinction is:

- `y_pred_*`: predictive moments in observation space before adding observation noise
- `y_obs_pred_*`: predictive moments for the actual observed data

In other words:

- `y_pred_mean = E[h(x_t) | y_{1:t-1}]`
- `y_pred_cov = Cov[h(x_t) | y_{1:t-1}]`
- `y_obs_pred_mean = y_pred_mean`
- `y_obs_pred_cov = y_pred_cov + R`

This is useful because different downstream tasks want different objects:

- latent-signal analysis or uncertainty decomposition: use `y_pred_*` [OPTIONAL]
- scoring rules against observed data: use `y_obs_pred_*` [ESSENTIAL TO THIS PR]

### EnKF

For EnKF, this PR newly exposes in `posterior_extras`:

- `y_ens_pred`: predicted observation ensemble

Unlike KF/EKF/UKF, EnKF does not return explicit `y_pred_mean` / `y_pred_cov` fields. Instead:

- noiseless predictive observation moments can be computed downstream from `y_ens_pred`
- the observation-level predictive covariance is already available as `S`

We now document `S` more clearly as the observation-predictive covariance used for assimilation and data scoring, i.e. the ensemble predictive covariance plus observation noise `R`.

This keeps EnKF lightweight while still exposing the important predictive information.

## Why `y_pred_*` vs `y_obs_pred_*` matters

There’s an important modeling distinction here:

- `y_pred_cov` reflects uncertainty from the latent state propagated into observation space
- `y_obs_pred_cov` reflects uncertainty in the actual measured observation, so it includes `R`

If we want to evaluate the predictive distribution of the observed data, the correct object is `y_obs_pred_cov`, not `y_pred_cov`.

That distinction is now explicit in the API instead of being left implicit in downstream code.

## Why DPF is not included

This PR does not extend `DPF`, as the predicted observations are not computed explicitly (hence, a bit more thought and work is needed for how to do this appropriately).

## Testing

Added regression coverage for:

- presence and shapes of the new predictive fields
- consistency between `y_pred_*` and state predictive moments for KF/EKF/UKF
- consistency of `y_obs_pred_cov = y_pred_cov + R`
- `output_fields=["posterior_extras"]` behavior
- EnKF behavior via newly exposed `y_ens_pred` and documented `S`