### PR TITLE
Add Missingness Support to the `ContDiscreteLinearGaussianSSM`

### DIFF
--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
@@ -487,7 +487,7 @@ def cdlgssm_filter(
         # accordingly:
         # H -> MH, D -> MD, d -> Md, R -> MRM+(I-M)/2π.
         # By constructing $ R = MRM + (I - M) / 2\pi, missing observations
-        # are scored as \log N(0; 0, 1/2\pi) = 0, and no special ll correction is needed. 
+        # are scored as \log N(0; 0, 1/2\pi) = 0, and no special ll correction is needed.
         masked_y = jnp.where(mask, y, 0.0)
         M = jnp.diag(mask.astype(H.dtype))
         identity = jnp.eye(len(mask), dtype=H.dtype)

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/inference.py
@@ -152,6 +152,7 @@ def preprocess_args(f):
         inputs = bound_args.arguments["inputs"]
         warn = bound_args.arguments["warn"]
         output_fields = bound_args.arguments.get("output_fields")
+        emission_mask = bound_args.arguments.get("emission_mask")
 
         num_timesteps = len(emissions)
         full_params, inputs = preprocess_params_and_inputs(
@@ -165,6 +166,7 @@ def preprocess_args(f):
             filter_hyperparams=filter_hyperparams,
             inputs=inputs,
             warn=warn,
+            emission_mask=emission_mask,
         )
         if output_fields is not None:
             call_kwargs["output_fields"] = output_fields
@@ -378,6 +380,7 @@ def cdlgssm_filter(
         "predicted_covariances",
     ],
     warn: bool = True,
+    emission_mask: Optional[Array] = None,
 ) -> PosteriorGSSMFiltered:
     r"""Run a Continuous Discrete Kalman filter
         to produce the marginal likelihood and filtered state estimates.
@@ -388,6 +391,10 @@ def cdlgssm_filter(
         t_emissions: continuous-time specific time instants of observations: if not None, it is an array
         filter_hyperparams: hyperparameters for the filter.
         inputs: optional array of inputs.
+        emission_mask: optional Boolean mask with shape `(num_timesteps,)`,
+            `(num_timesteps, 1)`, or the same shape as `emissions`. False
+            coordinates are excluded from the update and likelihood; their
+            emission values may be arbitrary, including `NaN`.
         output_fields: list of top-level posterior fields to return.
             Options:
             `"filtered_means"` (default)
@@ -411,6 +418,19 @@ def cdlgssm_filter(
     validate_filtered_posterior_output_fields(
         "cdlgssm_filter", output_fields, CDLGSSM_FILTER_OUTPUT_FIELDS
     )
+    if emission_mask is None:
+        emission_mask = jnp.ones_like(emissions, dtype=bool)
+    else:
+        emission_mask = jnp.asarray(emission_mask, dtype=bool)
+        if emission_mask.shape == (len(emissions),):
+            emission_mask = emission_mask[:, None]
+        if emission_mask.shape not in ((len(emissions), 1), emissions.shape):
+            raise ValueError(
+                "emission_mask must have shape (num_timesteps,), "
+                "(num_timesteps, 1), or match emissions; "
+                f"got {emission_mask.shape}."
+            )
+        emission_mask = jnp.broadcast_to(emission_mask, emissions.shape)
 
     # Figure out timestamps, as vectors to scan over
     # t_emissions is of shape num_timesteps \times 1
@@ -454,6 +474,7 @@ def cdlgssm_filter(
         # Get inputs and emissions at this time
         u = inputs[t0_idx]
         y = emissions[t0_idx]
+        mask = emission_mask[t0_idx]
 
         y_pred_mean, y_pred_cov = _emission_predicted_moments(
             pred_mean, pred_cov, H, D, d, u, warn=warn
@@ -461,12 +482,35 @@ def cdlgssm_filter(
         y_obs_pred_mean = y_pred_mean
         y_obs_pred_cov = psd(y_pred_cov + R, warn=warn)
 
-        # Update the log likelihood
-        ll += MVN(y_obs_pred_mean, y_obs_pred_cov).log_prob(y)
+        # Missing observations are replaced with 0.
+        # We then take M = diag(mask), and project observation-related quantities
+        # accordingly:
+        # H -> MH, D -> MD, d -> Md, R -> MRM+(I-M)/2π.
+        # By constructing $ R = MRM + (I - M) / 2\pi, missing observations
+        # are scored as \log N(0; 0, 1/2\pi) = 0, and no special ll correction is needed. 
+        masked_y = jnp.where(mask, y, 0.0)
+        M = jnp.diag(mask.astype(H.dtype))
+        identity = jnp.eye(len(mask), dtype=H.dtype)
+        R_full = jnp.diag(R) if R.ndim == 1 else R
+        masked_H, masked_D, masked_d = M @ H, M @ D, M @ d
+        masked_R = M @ R_full @ M + (identity - M) / (2.0 * jnp.pi)
 
-        # Condition on this emission
+        masked_y_pred_mean, masked_y_pred_cov = _emission_predicted_moments(
+            pred_mean, pred_cov, masked_H, masked_D, masked_d, u, warn=warn
+        )
+        masked_y_obs_pred_cov = psd(masked_y_pred_cov + masked_R, warn=warn)
+        ll += MVN(masked_y_pred_mean, masked_y_obs_pred_cov).log_prob(masked_y)
+
         filtered_mean, filtered_cov = _condition_on(
-            pred_mean, pred_cov, H, D, d, R, u, y, warn=warn
+            pred_mean,
+            pred_cov,
+            masked_H,
+            masked_D,
+            masked_d,
+            masked_R,
+            u,
+            masked_y,
+            warn=warn,
         )
 
         # Predict to the next time instant
@@ -598,6 +642,7 @@ def cdlgssm_smoother(
     inputs: Optional[Float[Array, "num_timesteps input_dim"]] = None,
     smoother_type: Optional[str] = "cd_smoother_1",
     warn: bool = True,
+    emission_mask: Optional[Array] = None,
 ) -> PosteriorGSSMSmoothed:
     r"""Run forward-filtering, backward-smoother to compute expectations
         under the posterior distribution on latent states.
@@ -608,6 +653,8 @@ def cdlgssm_smoother(
         emissions: array of observations.
         t_emissions: continuous-time specific time instants of observations: if not None, it is an array
         inputs: array of inputs.
+        emission_mask: optional Boolean mask indicating observed emission
+            entries. Accepted shapes and semantics match `cdlgssm_filter`.
         smoother_type:
             cd_smoother_1: Sarkka's Algorithm 3.17
             cd_smoother_2: Sarkka's Algorithm 3.18
@@ -636,7 +683,13 @@ def cdlgssm_smoother(
 
     # Run the Kalman filter
     filtered_posterior = cdlgssm_filter(
-        params, emissions, t_emissions, filter_hyperparams, inputs, warn=warn
+        params,
+        emissions,
+        t_emissions,
+        filter_hyperparams,
+        inputs,
+        warn=warn,
+        emission_mask=emission_mask,
     )
     # Unpack the filtered posterior
     ll, filtered_means, filtered_covs, *_ = filtered_posterior

--- a/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_linear_gaussian_ssm/models.py
@@ -482,6 +482,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
         inputs: Optional[Float[Array, "ntime input_dim"]] = None,
         key: PRNGKey = jr.PRNGKey(0),
         warn: bool = True,
+        emission_mask: Optional[Array] = None,
     ) -> Scalar:
         r"""Compute the marginal log likelihood of a sequence of emissions under the CD-LGSSM model.
 
@@ -493,12 +494,20 @@ class ContDiscreteLinearGaussianSSM(SSM):
             inputs: optional sequence of inputs.
             key: random number generator.
             warn: whether to warn about numerical issues.
+            emission_mask: optional Boolean mask indicating observed emission
+                entries. Accepted shapes and semantics match `cdlgssm_filter`.
         Returns:
             Marginal log likelihood of the emissions, $\log p(y_{1:T})$.
         """
         # Run CD-Kalman filter to compute marginal log likelihood
         filtered_posterior = cdlgssm_filter(
-            params, emissions, t_emissions, filter_hyperparams, inputs, warn=warn
+            params,
+            emissions,
+            t_emissions,
+            filter_hyperparams,
+            inputs,
+            warn=warn,
+            emission_mask=emission_mask,
         )
         return filtered_posterior.marginal_loglik
 
@@ -517,6 +526,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
             "predicted_covariances",
         ],
         warn: bool = True,
+        emission_mask: Optional[Array] = None,
     ) -> PosteriorGSSMFiltered:
         r"""Run the CD-Kalman filter to compute the filtered posterior distribution over states.
         Args:
@@ -540,6 +550,8 @@ class ContDiscreteLinearGaussianSSM(SSM):
                 top-level filtered posterior outputs. Unsupported fields raise
                 a `ValueError`.
             warn: whether to warn about numerical issues.
+            emission_mask: optional Boolean mask indicating observed emission
+                entries. Accepted shapes and semantics match `cdlgssm_filter`.
         Returns:
             filtered posterior distribution over states.
         """
@@ -553,6 +565,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
             inputs,
             output_fields=output_fields,
             warn=warn,
+            emission_mask=emission_mask,
         )
 
     # High-level, user-friendly interface combining filtering and forecasting steps
@@ -565,6 +578,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
         inputs_filter=None,
         inputs_forecast=None,
         warn: bool = True,
+        emission_mask_filter: Optional[Array] = None,
     ):
         r"""Run the CD-Kalman filter to compute the filtered posterior distributions over states,
         and then run forecasting from the last filtered state.
@@ -577,6 +591,9 @@ class ContDiscreteLinearGaussianSSM(SSM):
             inputs_filter: optional sequence of inputs for filtering.
             inputs_forecast: optional sequence of inputs for forecasting.
             warn: whether to warn about numerical issues.
+            emission_mask_filter: optional Boolean mask for the filtering
+                emissions. Accepted shapes and semantics match
+                `cdlgssm_filter`.
 
         Returns:
             filtered and forecasted posterior distributions over states.
@@ -589,6 +606,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
             t_emissions=t_emissions_filter,
             inputs=inputs_filter,
             warn=warn,
+            emission_mask=emission_mask_filter,
         )
 
         # Initialize forecast with last filtered state
@@ -619,6 +637,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
         filter_hyperparams: Optional[KFHyperParams] = KFHyperParams(),
         inputs: Optional[Float[Array, "ntime input_dim"]] = None,
         warn: bool = True,
+        emission_mask: Optional[Array] = None,
     ) -> PosteriorGSSMSmoothed:
         r"""Compute the smoothing distribution over states using the CD-Kalman smoother.
 
@@ -628,13 +647,21 @@ class ContDiscreteLinearGaussianSSM(SSM):
             t_emissions: continuous-time specific time instants of observations: if not None, it is an array
             filter_hyperparams: hyperparameters for the Kalman filter.
             inputs: optional sequence of inputs.
+            emission_mask: optional Boolean mask indicating observed emission
+                entries. Accepted shapes and semantics match `cdlgssm_filter`.
 
         Returns:
             smoothed posterior distributions over states.
         """
 
         return cdlgssm_smoother(
-            params, emissions, t_emissions, filter_hyperparams, inputs, warn=warn
+            params,
+            emissions,
+            t_emissions,
+            filter_hyperparams,
+            inputs,
+            warn=warn,
+            emission_mask=emission_mask,
         )
 
     # Sampling from the posterior distribution of states given emissions
@@ -667,6 +694,7 @@ class ContDiscreteLinearGaussianSSM(SSM):
         t_emissions: Optional[Float[Array, "ntime 1"]] = None,
         filter_hyperparams: Optional[KFHyperParams] = KFHyperParams(),
         inputs: Optional[Float[Array, "ntime input_dim"]] = None,
+        emission_mask: Optional[Array] = None,
     ) -> Tuple[Float[Array, "ntime emission_dim"], Float[Array, "ntime emission_dim"]]:
         r"""Compute marginal posterior predictive smoothing distribution for each observation.
 
@@ -676,6 +704,8 @@ class ContDiscreteLinearGaussianSSM(SSM):
             t_emissions: continuous-time specific time instants of observations: if not None, it is an array
             filter_hyperparams: hyperparameters for the Kalman filter.
             inputs: optional sequence of inputs.
+            emission_mask: optional Boolean mask indicating observed emission
+                entries. Accepted shapes and semantics match `cdlgssm_filter`.
 
         Returns:
             :posterior predictive means $\mathbb{E}[y_{t,d} \mid y_{1:T}]$ and standard deviations $\mathrm{std}[y_{t,d} \mid y_{1:T}]$
@@ -683,7 +713,12 @@ class ContDiscreteLinearGaussianSSM(SSM):
         """
         # Run CD-Kalman smoother to compute smoothed states
         posterior = cdlgssm_smoother(
-            params, emissions, t_emissions, filter_hyperparams, inputs
+            params,
+            emissions,
+            t_emissions,
+            filter_hyperparams,
+            inputs,
+            emission_mask=emission_mask,
         )
         # Compute posterior predictive for emissions
         H = params.emissions.weights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include = ["cd_dynamax*"]
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "ruff",
+    "ruff<0.16.0",
     "mkdocs-material>=9.7.1",
     "mkdocs>=1.6.1,<2",
     "mypy>=1.19.1",

--- a/tests/test_cdlgssm_missing_emissions.py
+++ b/tests/test_cdlgssm_missing_emissions.py
@@ -1,0 +1,188 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from cd_dynamax import (
+    ContDiscreteLinearGaussianSSM,
+    KFHyperParams,
+    cdlgssm_filter,
+)
+from cd_dynamax.dynamax.parameters import ParameterProperties
+
+
+def _fixed(value):
+    return {
+        "params": value,
+        "props": ParameterProperties(trainable=False),
+    }
+
+
+def _make_model(state_dim=2, emission_dim=2):
+    model = ContDiscreteLinearGaussianSSM(
+        state_dim=state_dim,
+        emission_dim=emission_dim,
+        has_dynamics_bias=False,
+        has_emissions_bias=False,
+    )
+    params, _ = model.initialize()
+    return model, params
+
+
+def test_timestep_mask_matches_dropping_missing_emissions():
+    model, params = _make_model()
+    t_emissions = jnp.array([[0.0], [0.1], [0.25], [0.4], [0.7]])
+    emissions = jnp.array(
+        [
+            [0.2, -0.1],
+            [jnp.nan, jnp.nan],
+            [0.4, 0.3],
+            [jnp.nan, jnp.nan],
+            [-0.2, 0.5],
+        ]
+    )
+    emission_mask = jnp.array([True, False, True, False, True])
+    observed = np.asarray(emission_mask)
+    hyperparams = KFHyperParams(diffeqsolve_settings={"dt0": 0.01})
+
+    masked_filter = model.filter(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=hyperparams,
+        emission_mask=emission_mask[:, None],
+        warn=False,
+    )
+    reference_filter = model.filter(
+        params=params,
+        emissions=emissions[observed],
+        t_emissions=t_emissions[observed],
+        filter_hyperparams=hyperparams,
+        warn=False,
+    )
+
+    np.testing.assert_allclose(
+        masked_filter.filtered_means[observed],
+        reference_filter.filtered_means,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+    np.testing.assert_allclose(
+        masked_filter.filtered_covariances[observed],
+        reference_filter.filtered_covariances,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+    np.testing.assert_allclose(
+        masked_filter.marginal_loglik,
+        reference_filter.marginal_loglik,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+
+    masked_smoother = model.smoother(
+        params=params,
+        emissions=emissions,
+        t_emissions=t_emissions,
+        filter_hyperparams=hyperparams,
+        emission_mask=emission_mask,
+        warn=False,
+    )
+    reference_smoother = model.smoother(
+        params=params,
+        emissions=emissions[observed],
+        t_emissions=t_emissions[observed],
+        filter_hyperparams=hyperparams,
+        warn=False,
+    )
+
+    np.testing.assert_allclose(
+        masked_smoother.smoothed_means[observed],
+        reference_smoother.smoothed_means,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+    np.testing.assert_allclose(
+        masked_smoother.smoothed_covariances[observed],
+        reference_smoother.smoothed_covariances,
+        rtol=1e-6,
+        atol=1e-7,
+    )
+
+
+def test_partial_emission_mask_matches_scalar_gaussian_update():
+    model = ContDiscreteLinearGaussianSSM(
+        state_dim=2,
+        emission_dim=2,
+        has_dynamics_bias=False,
+        has_emissions_bias=False,
+    )
+    initial_mean = jnp.array([0.1, -0.2])
+    initial_cov = jnp.array([[1.2, 0.25], [0.25, 0.8]])
+    emission_weights = jnp.array([[1.0, 0.4], [-0.3, 0.8]])
+    emission_cov = jnp.array([[0.3, 0.1], [0.1, 0.5]])
+    params, _ = model.initialize(
+        initial_mean=_fixed(initial_mean),
+        initial_cov=_fixed(initial_cov),
+        emission_weights=_fixed(emission_weights),
+        emission_cov=_fixed(emission_cov),
+    )
+
+    observed_value = 0.7
+    posterior = cdlgssm_filter(
+        params=params,
+        emissions=jnp.array([[observed_value, jnp.nan]]),
+        t_emissions=jnp.array([[0.0]]),
+        emission_mask=jnp.array([[True, False]]),
+        warn=False,
+    )
+
+    H_observed = emission_weights[:1]
+    predicted_observation = H_observed @ initial_mean
+    innovation_cov = H_observed @ initial_cov @ H_observed.T + emission_cov[:1, :1]
+    gain = jnp.linalg.solve(innovation_cov, H_observed @ initial_cov).T
+    expected_mean = initial_mean + gain[:, 0] * (
+        observed_value - predicted_observation[0]
+    )
+    expected_cov = initial_cov - gain @ innovation_cov @ gain.T
+    expected_loglik = -0.5 * (
+        jnp.log(2.0 * jnp.pi * innovation_cov[0, 0])
+        + (observed_value - predicted_observation[0]) ** 2 / innovation_cov[0, 0]
+    )
+
+    np.testing.assert_allclose(
+        posterior.filtered_means[0], expected_mean, rtol=1e-6, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        posterior.filtered_covariances[0], expected_cov, rtol=1e-6, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        posterior.marginal_loglik, expected_loglik, rtol=1e-6, atol=1e-7
+    )
+
+
+def test_all_missing_emissions_leave_initial_distribution_unchanged():
+    _, params = _make_model(state_dim=2, emission_dim=1)
+    posterior = cdlgssm_filter(
+        params=params,
+        emissions=jnp.full((1, 1), jnp.nan),
+        t_emissions=jnp.array([[0.0]]),
+        emission_mask=jnp.array([False]),
+        warn=False,
+    )
+
+    np.testing.assert_allclose(posterior.filtered_means[0], params.initial.mean)
+    np.testing.assert_allclose(posterior.filtered_covariances[0], params.initial.cov)
+    np.testing.assert_allclose(posterior.marginal_loglik, 0.0, atol=1e-7)
+
+
+def test_invalid_emission_mask_shape_raises():
+    _, params = _make_model(state_dim=1, emission_dim=2)
+
+    with pytest.raises(ValueError, match="emission_mask must have shape"):
+        cdlgssm_filter(
+            params=params,
+            emissions=jnp.zeros((3, 2)),
+            t_emissions=jnp.arange(3.0)[:, None],
+            emission_mask=jnp.ones((2, 2), dtype=bool),
+            warn=False,
+        )


### PR DESCRIPTION
This PR adds support for missing observations to the KF/RTS smoother. This is handled by a new parameter, `emission_mask`, which marks which observations (and optionally, which of their coordinates) are missing.

Missingness is handled by projecting observation-related quantities with the mask $\mathrm{diag}(M)$; so $H$ becomes $MH$, $D$ becomes $DH$, and $R$ becomes $MRM + (I-M)/2\pi$. The final of these, $R$, is chosen such that when missing quantities are replaced by $0$, their contribution to the log-likelihood is $N(0; 0, \sigma^2$, where $\sigma^2 = [MRM + (I - M)/2\pi]_j = (0 + 1/2\pi) = 1/2\pi$. Therefore, $\log N(0; 0, 1/2\pi) = 0$, and the corresponding log-likelihood is correct.

Accompanying test coverage can be found in `test_cdnlgssm_missing_emissions.py`. A concrete use case is in an upcoming GP notebook, that will be stacked with this PR.