### PR TITLE
Make EnKF covariance inflation autodifferentiable

### DIFF
--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/inference_enkf.py
@@ -81,7 +81,7 @@ class EnKFHyperParams(NamedTuple):
     N_particles: float = 25
     perturb_measurements: bool = True
     cov_rescaling: float = 1.0
-    inflation_delta: float = 0.0  # Inflation factor for ensemble spread
+    inflation_delta: Optional[float] = None  # Inflation factor for ensemble spread
     diffeqsolve_settings: dict = {}
     state_order: str = "first"
     dt_average: float = 0.1  # Average timestep for discrete state order, if applicable
@@ -206,7 +206,7 @@ def _condition_on(
     y,
     t,
     perturb_measurements=True,
-    inflation_delta=0.0,
+    inflation_delta=None,
     warn: bool = True,
 ):
     """Condition a Gaussian potential on a new observation
@@ -221,7 +221,8 @@ def _condition_on(
         y (D_obs,): observation.black
         t: time-instant of conditioning
         perturb_measurements: whether to perturb the measurements.
-        inflation_delta: inflation factor for ensemble spread.
+        inflation_delta: inflation factor for ensemble spread. If `None`,
+            inflation is disabled.
         warn: whether to warn about PSD issues.
 
     Returns:
@@ -275,7 +276,7 @@ def _condition_on(
     ll_step = MVN(y_pred_mean, y_pred_cov + R).log_prob(y)
 
     # === Inflate ensemble for assimilation if requested ===
-    if inflation_delta > 0.0:
+    if inflation_delta is not None:
         x_mean = jnp.mean(x, axis=0)
         x_inflated = x_mean + (1.0 + inflation_delta) * (x - x_mean)
         # re-propagate inflated ensemble through emission fn for assimilation

--- a/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
+++ b/cd_dynamax/src/continuous_discrete_nonlinear_gaussian_ssm/models.py
@@ -613,7 +613,7 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
         filter_state_cov_rescaling: float = 1.0,
         filter_dt_average: float = 0.1,
         enkf_N_particles: int = 25,
-        enkf_inflation_delta: float = 0.0,
+        enkf_inflation_delta: Optional[float] = None,
         diffeqsolve_max_steps: int = 100,
         diffeqsolve_dt0: float = 1e-2,
         output_fields=[
@@ -641,7 +641,8 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
             filter_state_cov_rescaling: Rescale state covariance by this factor after each update (inflation delta is better for accurate likelihoods)
             filter_dt_average: [Only for state_order="Discrete"] Average step size to determine constant state noise cov in filter.
             enkf_N_particles: Number of particles (for EnKF only).
-            enkf_inflation_delta: EnKF covariance inflation (ignored by EKF/UKF).
+            enkf_inflation_delta: EnKF covariance inflation; `None` disables it
+                (ignored by EKF/UKF).
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
             output_fields: Which top-level posterior fields to return from the
@@ -716,7 +717,7 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
         filter_state_cov_rescaling: float = 1.0,
         filter_dt_average: float = 0.1,
         enkf_N_particles: int = 25,
-        enkf_inflation_delta: float = 0.0,
+        enkf_inflation_delta: Optional[float] = None,
         diffeqsolve_max_steps: int = 100,
         diffeqsolve_dt0: float = 1e-2,
         key=jr.PRNGKey(0),
@@ -742,7 +743,8 @@ class ContDiscreteNonlinearGaussianSSM(SSM):
             filter_state_cov_rescaling: Rescale state covariance by this factor after each update (inflation delta is better for accurate likelihoods)
             filter_dt_average: [Only for state_order="Discrete"] Average step size to determine constant state noise cov in filter.
             enkf_N_particles: Number of particles (for EnKF only).
-            enkf_inflation_delta: EnKF covariance inflation (ignored by EKF/UKF).
+            enkf_inflation_delta: EnKF covariance inflation; `None` disables it
+                (ignored by EKF/UKF).
             diffeqsolve_max_steps: Max steps for ODE solver between observations.
             diffeqsolve_dt0: Initial step size for ODE/SDE solver (default is fixed step size).
             key: Random number generator key.
@@ -1458,7 +1460,7 @@ def build_filter_hyperparams(
     filter_state_cov_rescaling: float = 1.0,
     filter_dt_average: float = 0.1,
     enkf_N_particles: int = 25,
-    enkf_inflation_delta: float = 0.0,
+    enkf_inflation_delta: Optional[float] = None,
     diffeqsolve_max_steps: int = 100,
     diffeqsolve_dt0: float = 1e-2,
     diffeqsolve_kwargs: Optional[dict] = {},

--- a/tests/test_nonlinear_gaussian_filter_posterior_extras.py
+++ b/tests/test_nonlinear_gaussian_filter_posterior_extras.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -13,6 +14,7 @@ from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_ekf imp
     extended_kalman_filter,
 )
 from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_enkf import (
+    _condition_on,
     ensemble_kalman_filter,
 )
 from cd_dynamax.src.continuous_discrete_nonlinear_gaussian_ssm.inference_ukf import (
@@ -181,6 +183,30 @@ def test_enkf_predictive_observation_moments_are_top_level_outputs():
     assert jnp.all(jnp.isfinite(posterior.y_obs_pred_cov))
     assert jnp.allclose(posterior.y_obs_pred_mean, posterior.y_pred_mean)
     assert jnp.allclose(posterior.y_obs_pred_cov, posterior.y_pred_cov + R)
+
+
+def test_enkf_covariance_inflation_is_autodifferentiable():
+    x = jnp.array([[-1.0], [0.0], [2.0]])
+
+    def loss(inflation_delta):
+        result = _condition_on(
+            key=jr.PRNGKey(0),
+            x=x,
+            h=lambda state, inputs, time: state,
+            R=jnp.array([[0.5]]),
+            u=jnp.zeros(1),
+            y=jnp.array([0.25]),
+            t=0.0,
+            perturb_measurements=False,
+            inflation_delta=inflation_delta,
+            warn=False,
+        )
+        return jnp.sum(result["x_cond"] ** 2)
+
+    gradient = jax.jit(jax.grad(loss))(jnp.array(0.0))
+
+    assert jnp.isfinite(gradient)
+    assert not jnp.isclose(gradient, 0.0)
 
 
 def test_enkf_posterior_extras_are_not_returned_by_default():


### PR DESCRIPTION
## Summary

- Use `None` to disable EnKF covariance inflation without extra computation.
- Keep numeric inflation values, including `0.0`, compatible with JAX autodiff.
- Add regression test `jax.jit(jax.grad(...))`.